### PR TITLE
Optimizing conj and assoc and making their behavior match clj's more closely

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,11 @@ Run `npx clava --help` to see all command line options.
 
 ## Why Clava
 
-The selling point of clavascript is that you can write with CLJS syntax but get
-really small JS output, while still having parts of the standard library
-available (with caveats, based on mutable data structures). This may work for
-small projects e.g. that you'd like to deploy on CloudFlare workers, node
-scripts, Github actions, etc. that need the extra performance and small bundle
-size.
+Clava let you write CLJS syntax but emits small JS output, while still having
+parts of the CLJS standard library available (ported to mutable data structures,
+so with caveats). This may work for small projects e.g. that you'd like to
+deploy on CloudFlare workers, node scripts, Github actions, etc. that need the
+extra performance and small bundle size.
 
 ## Differences with ClojureScript
 

--- a/core.js
+++ b/core.js
@@ -25,7 +25,7 @@ export function assoc_BANG_(m, k, v, ...kvs) {
 }
 
 export function assoc(o, k, v, ...kvs) {
-  if (!o instanceof Object) {
+  if (!(o instanceof Object)) {
     throw new Error(
       'Illegal argument: assoc expects a Map, Array, or Object as the first argument.'
     );
@@ -38,6 +38,74 @@ export function assoc(o, k, v, ...kvs) {
   }
 
   return assoc_BANG_({ ...o }, k, v, ...kvs);
+}
+
+export function assoc_in(o, keys, value) {
+  if (!(o instanceof Object)) {
+    throw new Error(
+      'Illegal argument: assoc-in expects the first argument to be a Map, Array, or Object.'
+    );
+  }
+
+  if (!(keys instanceof Array)) {
+    throw new Error('Illegal argument: assoc-in expects the keys argument to be an Array.');
+  }
+
+  const chain = [o];
+  let lastInChain = o;
+
+  for (let i = 0; i < keys.length - 1; i += 1) {
+    const chainValue = lastInChain instanceof Map ? lastInChain.get(keys[i]) : lastInChain[keys[i]];
+    if (!(chainValue instanceof Object)) {
+      throw new Error(
+        'Illegal argument: assoc-in expects each intermediate value found via the keys array to be a Map, Array, or Object.'
+      );
+    }
+    chain.push(chainValue);
+    lastInChain = chainValue;
+  }
+
+  chain.push(value);
+
+  for (let i = chain.length - 2; i >= 0; i -= 1) {
+    chain[i] = assoc(chain[i], keys[i], chain[i + 1]);
+  }
+
+  return chain[0];
+}
+
+export function assoc_in_BANG_(o, keys, value) {
+  if (!(o instanceof Object)) {
+    throw new Error(
+      'Illegal argument: assoc-in expects the first argument to be a Map, Array, or Object.'
+    );
+  }
+
+  if (!(keys instanceof Array)) {
+    throw new Error('Illegal argument: assoc-in expects the keys argument to be an Array.');
+  }
+
+  const chain = [o];
+  let lastInChain = o;
+
+  for (let i = 0; i < keys.length - 1; i += 1) {
+    const chainValue = lastInChain instanceof Map ? lastInChain.get(keys[i]) : lastInChain[keys[i]];
+    if (!(chainValue instanceof Object)) {
+      throw new Error(
+        'Illegal argument: assoc-in expects each intermediate value found via the keys array to be a Map, Array, or Object.'
+      );
+    }
+    chain.push(chainValue);
+    lastInChain = chainValue;
+  }
+
+  chain.push(value);
+
+  for (let i = chain.length - 2; i >= 0; i -= 1) {
+    assoc_BANG_(chain[i], keys[i], chain[i + 1]);
+  }
+
+  return chain[0];
 }
 
 export function conj_BANG_(...xs) {
@@ -127,11 +195,11 @@ export function dissoc(m, k) {
 }
 
 export function inc(n) {
-  return n+1;
+  return n + 1;
 }
 
 export function dec(n) {
-  return n-1;
+  return n - 1;
 }
 
 export function println(...args) {
@@ -142,13 +210,21 @@ export function nth(coll, idx) {
   return coll[idx];
 }
 
+export function get(coll, key, otherwise = undefined) {
+  if (coll instanceof Map) {
+    return coll.has(key) ? coll.get(key) : otherwise;
+  }
+
+  return key in coll ? coll[key] : otherwise;
+}
+
 export function map(f, coll) {
   return coll.map(f);
 }
 
 export function str(...xs) {
-  let ret = "";
-  xs.forEach(x => ret = ret + x);
+  let ret = '';
+  xs.forEach((x) => (ret = ret + x));
   return ret;
 }
 
@@ -163,14 +239,11 @@ export function nil_QMARK_(v) {
 export const PROTOCOL_SENTINEL = {};
 
 function pr_str_1(x) {
-  return JSON.stringify(
-    x,
-    (_key, value) => (value instanceof Set ? [...value] : value)
-  );
+  return JSON.stringify(x, (_key, value) => (value instanceof Set ? [...value] : value));
 }
 
 export function pr_str(...xs) {
-  return xs.map(pr_str_1).join(" ");
+  return xs.map(pr_str_1).join(' ');
 }
 
 export function prn(...xs) {
@@ -180,7 +253,7 @@ export function prn(...xs) {
 export function Atom(init) {
   this.val = init;
   this._deref = () => this.val;
-  this._reset_BANG_ = (x) => this.val = x;
+  this._reset_BANG_ = (x) => (this.val = x);
 }
 
 export function atom(init) {
@@ -202,9 +275,11 @@ export function swap_BANG_(atm, f, ...args) {
 }
 
 export function range(begin, end) {
-  let b = begin, e = end;
+  let b = begin,
+    e = end;
   if (e === undefined) {
-    e = b; b = 0;
+    e = b;
+    b = 0;
   }
   let ret = [];
   for (let x = b; x < e; x++) {
@@ -235,7 +310,7 @@ export function vector(...args) {
 export function map_indexed(f, coll) {
   let ctr = 0;
   let f2 = (x) => {
-    let res = f(ctr,x);
+    let res = f(ctr, x);
     ctr = ctr + 1;
     return res;
   };

--- a/core.js
+++ b/core.js
@@ -127,11 +127,11 @@ export function dissoc(m, k) {
 }
 
 export function inc(n) {
-  return n + 1;
+  return n+1;
 }
 
 export function dec(n) {
-  return n - 1;
+  return n-1;
 }
 
 export function println(...args) {
@@ -147,8 +147,8 @@ export function map(f, coll) {
 }
 
 export function str(...xs) {
-  let ret = '';
-  xs.forEach((x) => (ret = ret + x));
+  let ret = "";
+  xs.forEach(x => ret = ret + x);
   return ret;
 }
 
@@ -163,11 +163,14 @@ export function nil_QMARK_(v) {
 export const PROTOCOL_SENTINEL = {};
 
 function pr_str_1(x) {
-  return JSON.stringify(x, (_key, value) => (value instanceof Set ? [...value] : value));
+  return JSON.stringify(
+    x,
+    (_key, value) => (value instanceof Set ? [...value] : value)
+  );
 }
 
 export function pr_str(...xs) {
-  return xs.map(pr_str_1).join(' ');
+  return xs.map(pr_str_1).join(" ");
 }
 
 export function prn(...xs) {
@@ -177,7 +180,7 @@ export function prn(...xs) {
 export function Atom(init) {
   this.val = init;
   this._deref = () => this.val;
-  this._reset_BANG_ = (x) => (this.val = x);
+  this._reset_BANG_ = (x) => this.val = x;
 }
 
 export function atom(init) {
@@ -199,11 +202,9 @@ export function swap_BANG_(atm, f, ...args) {
 }
 
 export function range(begin, end) {
-  let b = begin,
-    e = end;
+  let b = begin, e = end;
   if (e === undefined) {
-    e = b;
-    b = 0;
+    e = b; b = 0;
   }
   let ret = [];
   for (let x = b; x < e; x++) {
@@ -234,7 +235,7 @@ export function vector(...args) {
 export function map_indexed(f, coll) {
   let ctr = 0;
   let f2 = (x) => {
-    let res = f(ctr, x);
+    let res = f(ctr,x);
     ctr = ctr + 1;
     return res;
   };

--- a/core.js
+++ b/core.js
@@ -33,6 +33,8 @@ export function assoc(o, k, v, ...kvs) {
 
   if (o instanceof Map) {
     return assoc_BANG_(new Map(o.entries()), k, v, ...kvs);
+  } else if (o instanceof Array) {
+    return assoc_BANG_([...o], k, v, ...kvs);
   }
 
   return assoc_BANG_({ ...o }, k, v, ...kvs);
@@ -125,11 +127,11 @@ export function dissoc(m, k) {
 }
 
 export function inc(n) {
-  return n+1;
+  return n + 1;
 }
 
 export function dec(n) {
-  return n-1;
+  return n - 1;
 }
 
 export function println(...args) {
@@ -145,8 +147,8 @@ export function map(f, coll) {
 }
 
 export function str(...xs) {
-  let ret = "";
-  xs.forEach(x => ret = ret + x);
+  let ret = '';
+  xs.forEach((x) => (ret = ret + x));
   return ret;
 }
 
@@ -161,14 +163,11 @@ export function nil_QMARK_(v) {
 export const PROTOCOL_SENTINEL = {};
 
 function pr_str_1(x) {
-  return JSON.stringify(
-    x,
-    (_key, value) => (value instanceof Set ? [...value] : value)
-  );
+  return JSON.stringify(x, (_key, value) => (value instanceof Set ? [...value] : value));
 }
 
 export function pr_str(...xs) {
-  return xs.map(pr_str_1).join(" ");
+  return xs.map(pr_str_1).join(' ');
 }
 
 export function prn(...xs) {
@@ -178,7 +177,7 @@ export function prn(...xs) {
 export function Atom(init) {
   this.val = init;
   this._deref = () => this.val;
-  this._reset_BANG_ = (x) => this.val = x;
+  this._reset_BANG_ = (x) => (this.val = x);
 }
 
 export function atom(init) {
@@ -200,9 +199,11 @@ export function swap_BANG_(atm, f, ...args) {
 }
 
 export function range(begin, end) {
-  let b = begin, e = end;
+  let b = begin,
+    e = end;
   if (e === undefined) {
-    e = b; b = 0;
+    e = b;
+    b = 0;
   }
   let ret = [];
   for (let x = b; x < e; x++) {
@@ -233,7 +234,7 @@ export function vector(...args) {
 export function map_indexed(f, coll) {
   let ctr = 0;
   let f2 = (x) => {
-    let res = f(ctr,x);
+    let res = f(ctr, x);
     ctr = ctr + 1;
     return res;
   };

--- a/core.js
+++ b/core.js
@@ -1,56 +1,104 @@
-export function assoc_BANG_(m, k, v, ...kvs) {
-  m[k] = v;
-  if (kvs.length != 0) {
-    return assoc_BANG_(m, ...kvs);
+function assoc_BANG_(m, k, v, ...kvs) {
+  if (kvs.length % 2 !== 0) {
+    throw new Error('Illegal argument: assoc expects an odd number of arguments.');
   }
-  else return m;
+
+  if (m instanceof Map) {
+    m.set(k, v);
+
+    for (let i = 0; i < kvs.length; i += 2) {
+      m.set(kvs[i], m[kvs[i + 1]]);
+    }
+  } else if (m instanceof Object) {
+    m[k] = v;
+
+    for (let i = 0; i < kvs.length; i += 2) {
+      m[kvs[i]] = m[kvs[i + 1]];
+    }
+  } else {
+    throw new Error(
+      'Illegal argument: assoc! expects a Map, Array, or Object as the first argument.'
+    );
+  }
+
+  return m;
 }
 
 export function assoc(o, k, v, ...kvs) {
-  let o2 = { ...o };
-  return assoc_BANG_(o2, k, v, ...kvs);
+  if (!o instanceof Object) {
+    throw new Error(
+      'Illegal argument: assoc expects a Map, Array, or Object as the first argument.'
+    );
+  }
+  return assoc_BANG_({ ...o }, k, v, ...kvs);
 }
 
-const object = Object.getPrototypeOf({});
-const array = Object.getPrototypeOf([]);
-const set = Object.getPrototypeOf(new Set());
+function conj_BANG_(...xs) {
+  let [o, ...rest] = xs;
 
-export function conj_BANG_(o, x, ...xs) {
-  switch (Object.getPrototypeOf(o)) {
-  case object:
-    o[x[0]] = x[1];
-    break;
-  case array:
-    o.push(x);
-    break;
-  case set:
-    o.add(x);
-    break;
-  default:
-    o.conj_BANG_(x);
+  if (o === null || o === undefined) {
+    o = [];
   }
-  if (xs.length != 0) {
-    return conj_BANG_(o, ...xs);
+
+  if (o instanceof Set) {
+    for (const x of rest) {
+      o.add(x);
+    }
+  } else if (o instanceof Array) {
+    o.push(...rest);
+  } else if (o instanceof Map) {
+    for (const x of rest) {
+      o.set(x[0], x[1]);
+    }
+  } else if (o instanceof Object) {
+    for (const x of rest) {
+      o[x[0]] = x[1];
+    }
+  } else {
+    throw new Error(
+      'Illegal argument: conj! expects a Set, Array, Map, or Object as the first argument.'
+    );
   }
+
   return o;
 }
 
-export function conj(o, x, ...xs) {
-  switch (Object.getPrototypeOf(o)) {
-  case object:
-    let o2 = {...o};
-    return conj_BANG_(o2, x, ...xs);
-  case array:
-    return [...o, x, ...xs];
-  case set:
-    return new Set([...o, x, ...xs]);
-  default:
-    return o.conj(x, ...xs);
+export function conj(...xs) {
+  let [o, ...rest] = xs;
+
+  if (o === null || o === undefined) {
+    o = [];
   }
+
+  if (o instanceof Set) {
+    return new Set([...o, ...rest]);
+  } else if (o instanceof Array) {
+    return [...o, ...rest];
+  } else if (o instanceof Map) {
+    const m = new Map(o);
+
+    for (const x of rest) {
+      m.set(x[0], x[1]);
+    }
+
+    return m;
+  } else if (o instanceof Object) {
+    const o2 = { ...o };
+
+    for (const x of rest) {
+      o2[x[0]] = x[1];
+    }
+
+    return o2;
+  }
+
+  throw new Error(
+    'Illegal argument: conj expects a Set, Array, Map, or Object as the first argument.'
+  );
 }
 
 export function disj_BANG_(s, ...xs) {
-  for (let x of xs) {
+  for (const x of xs) {
     s.delete(x);
   }
   return s;

--- a/core.js
+++ b/core.js
@@ -223,9 +223,7 @@ export function map(f, coll) {
 }
 
 export function str(...xs) {
-  let ret = '';
-  xs.forEach((x) => (ret = ret + x));
-  return ret;
+  return xs.join('');
 }
 
 export function not(expr) {

--- a/core.js
+++ b/core.js
@@ -1,4 +1,4 @@
-function assoc_BANG_(m, k, v, ...kvs) {
+export function assoc_BANG_(m, k, v, ...kvs) {
   if (kvs.length % 2 !== 0) {
     throw new Error('Illegal argument: assoc expects an odd number of arguments.');
   }
@@ -7,13 +7,13 @@ function assoc_BANG_(m, k, v, ...kvs) {
     m.set(k, v);
 
     for (let i = 0; i < kvs.length; i += 2) {
-      m.set(kvs[i], m[kvs[i + 1]]);
+      m.set(kvs[i], kvs[i + 1]);
     }
   } else if (m instanceof Object) {
     m[k] = v;
 
     for (let i = 0; i < kvs.length; i += 2) {
-      m[kvs[i]] = m[kvs[i + 1]];
+      m[kvs[i]] = kvs[i + 1];
     }
   } else {
     throw new Error(
@@ -30,10 +30,15 @@ export function assoc(o, k, v, ...kvs) {
       'Illegal argument: assoc expects a Map, Array, or Object as the first argument.'
     );
   }
+
+  if (o instanceof Map) {
+    return assoc_BANG_(new Map(o.entries()), k, v, ...kvs);
+  }
+
   return assoc_BANG_({ ...o }, k, v, ...kvs);
 }
 
-function conj_BANG_(...xs) {
+export function conj_BANG_(...xs) {
   let [o, ...rest] = xs;
 
   if (o === null || o === undefined) {

--- a/test/clava/compiler_test.cljs
+++ b/test/clava/compiler_test.cljs
@@ -13,6 +13,8 @@
 (aset js/globalThis "nil_QMARK_" cl/not)
 (aset js/globalThis "pr_str" cl/pr_str)
 (aset js/globalThis "conj" cl/conj)
+(aset js/globalThis "assoc" cl/assoc)
+(aset js/globalThis "assoc_BANG_" cl/assoc!)
 (aset js/globalThis "PROTOCOL_SENTINEL" cl/PROTOCOL_SENTINEL)
 
 (defn eq [a b]
@@ -372,8 +374,12 @@
   (testing "arrays"
     (is (eq [1 2 8 4] (jsv! (assoc [1 2 3 4] 2 8))))
     (is (eq [6 2 8 4] (jsv! (assoc [1 2 3 4] 2 8 0 6)))))
-  #_(testing "maps")
-  #_(testing "objects"))
+  (testing "objects"
+    (is (eq #js {"1" 2 "3" 4} (jsv! '(assoc {"1" 2} "3" 4))))
+    (is (eq #js {"1" 2 "3" 4 "5" 6} (jsv! '(assoc {"1" 2} "3" 4 "5" 6)))))
+  (testing "maps"
+    (is (eq (js/Map. #js [#js [1 2] #js [3 4]]) (jsv! '(assoc (js/Map. [[1 2]]) 3 4))))
+    (is (eq (js/Map. #js [#js [1 2] #js [3 4] #js [5 6]]) (jsv! '(assoc (js/Map. [[1 2]]) 3 4 5 6))))))
 
 (defn init []
   (cljs.test/run-tests 'clava.compiler-test))

--- a/test/clava/compiler_test.cljs
+++ b/test/clava/compiler_test.cljs
@@ -8,7 +8,7 @@
 
 (aset js/globalThis "map" cl/map)
 (aset js/globalThis "dissoc_BANG_" cl/dissoc!)
-(aset js/globalThis "str" cl/dissoc!)
+(aset js/globalThis "str" cl/str)
 (aset js/globalThis "not" cl/not)
 (aset js/globalThis "get" cl/get)
 (aset js/globalThis "nil_QMARK_" cl/not)
@@ -349,6 +349,12 @@
 
 (deftest pr-str-test
   (is (eq (js/Set. #js ["a" "b" "c"]) (js/Set. (js/JSON.parse (jsv! '(pr-str #{:a :b :c})))))))
+
+(deftest str-test
+  (is (eq "123" (jsv! '(str 1 2 3))))
+  (is (eq "foobarbaz", (jsv! '(str "foo" "bar" "baz"))))
+  (is (eq "1barfirst,second[object Object]"
+          (jsv! '(str 1 "bar" [:first :second] {"hello" "goodbye"})))))
 
 (deftest conj-test
   (testing "corner cases"

--- a/test/clava/compiler_test.cljs
+++ b/test/clava/compiler_test.cljs
@@ -4,7 +4,7 @@
    ["lodash$default" :as ld]
    [clava.compiler :as clava]
    [clojure.string :as str]
-   [clojure.test :as t :refer [async deftest is]]))
+   [clojure.test :as t :refer [async deftest is testing]]))
 
 (aset js/globalThis "map" cl/map)
 (aset js/globalThis "dissoc_BANG_" cl/dissoc!)
@@ -345,7 +345,33 @@
   (is (eq (js/Set. #js ["a" "b" "c"]) (js/Set. (js/JSON.parse (jsv! '(pr-str #{:a :b :c})))))))
 
 (deftest conj-test
-  (is (eq [1 2 3 4] (jsv! '(conj [1 2 3] 4)))))
+  (testing "corner cases"
+    (is (eq [], (jsv! '(conj))))
+    (is (eq [], (jsv! '(conj nil))))
+    (is (eq [1 2], (jsv! '(conj nil 1 2)))))
+  (testing "arrays"
+    (is (eq [1 2 3 4] (jsv! '(conj [1 2 3 4]))))
+    (is (eq [1 2 3 4] (jsv! '(conj [1 2 3] 4))))
+    (is (eq [1 2 3 4] (jsv! '(conj [1 2] 3 4)))))
+  (testing "sets"
+    (is (eq (js/Set. #js [1 2 3 4]) (jsv! '(conj #{1 2 3 4}))))
+    (is (eq (js/Set. #js [1 2 3 4]) (jsv! '(conj #{1 2 3} 4))))
+    (is (eq (js/Set. #js [1 2 3 4]) (jsv! '(conj #{1 2} 3 4)))))
+  #_(testing "maps"
+    (is (eq (js/Map. #js [["a" "b"] ["c" "d"]]) (jsv! '(conj #js {"a" "b" "c" "d"}))))
+    (is (eq (js/Map. #js [[1 2] [3 4]]) (jsv! '(conj {1 2} [3 4]))))
+    (is (eq (js/Map. #js [[1 2] [3 4] [5 6]]) (jsv! '(conj {1 2} [3 4] [5 6])))))
+  #_(testing "objects"
+    (is (eq #js {"a" "b" "c" "d"} (jsv! '(conj #js {"a" "b" "c" "d"})))))
+  #_(testing "other types"
+    (is (isa? Error (jsv! '(conj "foo"))))))
+
+(deftest assoc-test
+  (testing "arrays"
+    (is (eq [1 2 8 4] (jsv! (assoc [1 2 3 4] 2 8))))
+    (is (eq [6 2 8 4] (jsv! (assoc [1 2 3 4] 2 8 0 6)))))
+  #_(testing "maps")
+  #_(testing "objects"))
 
 (defn init []
   (cljs.test/run-tests 'clava.compiler-test))

--- a/test/clava/compiler_test.cljs
+++ b/test/clava/compiler_test.cljs
@@ -338,6 +338,7 @@
   (is (= -11 (jsv! '(- 10 21)))))
 
 (deftest namespace-keywords
+  (is (eq #js {"foo/bar" "baz"} (jsv! {:foo/bar :baz})))
   (is (eq "hello/world" (jsv! "(ns hello) ::world"))))
 
 (deftest pr-str-test


### PR DESCRIPTION
These appear to be significantly faster than the original functions and handle more corner cases in order to more closely match clojure's conj/assoc functions.

**EDIT**: I added get + assoc-in + assoc-in! as a bonus on this PR, and sped up str / added tests for it.