### PR TITLE
Iterable protocol

### DIFF
--- a/core.js
+++ b/core.js
@@ -295,13 +295,15 @@ function iterable(x) {
   return Object.entries(x);
 }
 
-export const Iterable = Symbol('Iterable');
+export const IIterable = Symbol('Iterable');
 
-export const Iterable_es6_iterator = Symbol.iterator;
+export const IIterable__iterator = Symbol.iterator;
 
-export function es6_iterator(coll) {
+export function _iterator(coll) {
   return coll[Symbol.iterator]();
 }
+
+export const es6_iterator = _iterator;
 
 export function seq(x) {
   let iter = iterable(x);

--- a/core.js
+++ b/core.js
@@ -295,6 +295,10 @@ function iterable(x) {
   return Object.entries(x);
 }
 
+export const Iterable = Symbol('Iterable');
+
+export const Iterable_es6_iterator = Symbol.iterator;
+
 export function es6_iterator(coll) {
   return coll[Symbol.iterator]();
 }

--- a/resources/clava/core.edn
+++ b/resources/clava/core.edn
@@ -1,8 +1,9 @@
 #{Atom
-  Iterable
-  Iterable_es6_iterator
+  IIterable
+  IIterable__iterator
   PROTOCOL_SENTINEL
   _PLUS_
+  _iterator
   apply
   array_QMARK_
   assoc

--- a/resources/clava/core.edn
+++ b/resources/clava/core.edn
@@ -1,4 +1,6 @@
 #{Atom
+  Iterable
+  Iterable_es6_iterator
   PROTOCOL_SENTINEL
   _PLUS_
   apply

--- a/test/clava/compiler_test.cljs
+++ b/test/clava/compiler_test.cljs
@@ -911,11 +911,11 @@
 (deftest iterable-protocol
   (is (eq [true true [1 2 3 4 5]]
           (jsv! '(do (deftype Foo []
-                       Iterable
-                       (es6-iterator [_]
-                         ;; es6-iterator must return an _iterator_,
+                       IIterable
+                       (-iterator [_]
+                         ;; -iterator must return a JS Iterator object,
                          ;; not another iterable
-                         (es6-iterator [0 1 2 3 4])))
+                         (-iterator [0 1 2 3 4])))
                      (let [foo (->Foo)]
                        [(seqable? foo)
                         (= foo (seq foo))

--- a/test/clava/compiler_test.cljs
+++ b/test/clava/compiler_test.cljs
@@ -907,5 +907,19 @@
   (testing "other types"
     (is (thrown? js/Error (jsv! '(into "foo" []))))))
 
+
+(deftest iterable-protocol
+  (is (eq [true true [1 2 3 4 5]]
+          (jsv! '(do (deftype Foo []
+                       Iterable
+                       (es6-iterator [_]
+                         ;; es6-iterator must return an _iterator_,
+                         ;; not another iterable
+                         (es6-iterator [0 1 2 3 4])))
+                     (let [foo (->Foo)]
+                       [(seqable? foo)
+                        (= foo (seq foo))
+                        (map inc (->Foo))]))))))
+
 (defn init []
   (cljs.test/run-tests 'clava.compiler-test))


### PR DESCRIPTION
PR for implementing the JS iterable protocol as an actual Clava protocol that can be extended to Clava types, addressing #125