### PR TITLE
satisfies? works on number and string

### DIFF
--- a/core.js
+++ b/core.js
@@ -8,7 +8,7 @@ export function _PLUS_(x, ...xs) {
 }
 
 export function satisfies_QMARK_(protocol, x) {
-  return protocol in x && x[protocol];
+  return x[protocol];
 }
 
 export function assoc_BANG_(m, k, v, ...kvs) {

--- a/test/clava/compiler_test.cljs
+++ b/test/clava/compiler_test.cljs
@@ -308,7 +308,7 @@
 
 (deftest satisfies?-test
   #_#_(is (jsv! '(do (defprotocol IFoo)
-                 (satisfies? (reify IFoo)))))
+                     (satisfies? (reify IFoo)))))
   (is (jsv! '(do (defprotocol IFoo (-foo [_]))
                  (satisfies? (reify IFoo
                                (-foo [_] "bar"))))))
@@ -317,7 +317,13 @@
                  (satisfies? IFoo (->Foo)))))
   (is (jsv! '(do (defprotocol IFoo (-foo [_]))
                  (deftype Foo [] IFoo (-foo [_] "bar"))
-                 (satisfies? IFoo (->Foo))))))
+                 (satisfies? IFoo (->Foo)))))
+  (is (jsv! '(do (defprotocol IFoo)
+                 (extend-type number IFoo)
+                 (satisfies? IFoo 1))))
+  (is (jsv! '(do (defprotocol IFoo)
+                 (extend-type string IFoo)
+                 (satisfies? IFoo "bar")))))
 
 (deftest set-test
   (is (ld/isEqual (js/Set. #js [1 2 3]) (jsv! #{1 2 3}))))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code): [#issue-number](https://github.com/clavascript/clavascript/issues/...) (mention the issue number in the previous link and remove this text)
- [x] This PR provides tests for code additions and changes
- [x] This PR does not contain bonus changes, i.e. changes not discussed in the linked issue. For those, please submit a new issue + PR.

After submitting this PR, please do not force-push your branch as this makes
collaboration easier. Push as many new commits to your branch, they will be
squashed upon merge.

---

`in` doesn't work on numbers and string primitives, so just use property access. #128 related.

This still doesn't support `nil`, which I will create another issue for.