### PR TITLE
reduce performance

### DIFF
--- a/core.js
+++ b/core.js
@@ -1,6 +1,6 @@
 // @ts-check
-export function _PLUS_(x, ...xs) {
-  let sum = x;
+export function _PLUS_(x, y, ...xs) {
+  let sum = x + y || 0;
   for (const y of xs) {
     sum += y;
   }
@@ -406,9 +406,9 @@ export function reduce(f, arg1, arg2) {
   let coll, val;
   if (arg2 === undefined) {
     // (reduce f coll)
-    const [hd, ...more] = iterable(arg1);
-    val = hd;
-    coll = more;
+    let iter = iterable(arg1)[Symbol.iterator]();
+    val = iter.next().value;
+    coll = iter;
   } else {
     // (reduce f val coll)
     val = arg1;

--- a/core.js
+++ b/core.js
@@ -1,9 +1,10 @@
 // @ts-check
 export function _PLUS_(x, y, ...xs) {
   let sum = x + y || 0;
-  for (const y of xs) {
-    sum += y;
-  }
+  if (xs.length !== 0)
+    for (const y of xs) {
+      sum += y;
+    }
   return sum;
 }
 

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
     <script type="importmap">
       {
         "imports": {
-          "clavascript": "https://cdn.jsdelivr.net/npm/clavascript@0.0.0-alpha.23/index.js",
-          "clavascript/core.js": "https://cdn.jsdelivr.net/npm/clavascript@0.0.0-alpha.23/core.js"
+          "clavascript": "https://cdn.jsdelivr.net/npm/clavascript@0.0.0-alpha.24/index.js",
+          "clavascript/core.js": "https://cdn.jsdelivr.net/npm/clavascript@0.0.0-alpha.24/core.js"
         }
       }
     </script>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "clavascript",
   "type": "module",
   "sideEffects": false,
-  "version": "0.0.0-alpha.23",
+  "version": "0.0.0-alpha.24",
   "files": [
     "cljs.core.js",
     "core.js",


### PR DESCRIPTION
This PR speeds up reduce performance for large iterable inputs.

With this PR:

```
$ ./node_cli.js -e '(let [nums (vec (range 100000000))] (time (prn (reduce + nums))))'
4999999950000000
"Elapsed time: 943.758708 msecs"
```

With the previous version this took about 3x as long.
