### PR TITLE
LazySeq

### DIFF
--- a/core.js
+++ b/core.js
@@ -1031,3 +1031,12 @@ export function frequencies(coll) {
   }
   return res;
 }
+
+export class LazySeq {
+  constructor(f) {
+    this.f = f;
+  }
+  *[Symbol.iterator]() {
+    yield* this.f();
+  }
+}

--- a/resources/clava/core.edn
+++ b/resources/clava/core.edn
@@ -1,6 +1,7 @@
 #{Atom
   IIterable
   IIterable__iterator
+  LazySeq
   PROTOCOL_SENTINEL
   _
   _PLUS_

--- a/src/clava/internal/macros.cljc
+++ b/src/clava/internal/macros.cljc
@@ -193,7 +193,7 @@
   is called, and will cache the result and return it on all subsequent
   seq calls."
   [_ _ & body]
-  `(new cljs.core/LazySeq nil (fn [] ~@body) nil nil))
+  `(new cljs.core/LazySeq (fn [] ~@body)))
 
 (defn core-for
   "List comprehension. Takes a vector of one or more


### PR DESCRIPTION
@lilactown This makes the following example work:

``` clojure
$ ./node_cli.js -e '(def fib (concat [0 1] (lazy-seq (map + fib (rest fib))))) (time (prn (take 26 fib)))'
[0,1,1,2,3,5,8,13,21,34,55,89,144,233,377,610,987,1597,2584,4181,6765,10946,17711,28657,46368,75025]
"Elapsed time: 525.905208 msecs"
```

Due to non-caching it's much slower than in CLJS, but at least it works :)

I'm sure you have some feedback on this though. 