### PR TITLE
replace stub of `integer?` with proper function

### DIFF
--- a/src/squint/core.js
+++ b/src/squint/core.js
@@ -2477,7 +2477,9 @@ export function int_QMARK_(x) {
   return Number.isInteger(x);
 }
 
-export const integer_QMARK_ = int_QMARK_;
+export function integer_QMARK_(x) {
+  return typeof x == 'bigint' || int_QMARK_(x);
+}
 
 export function pos_int_QMARK_(x) {
   return int_QMARK_(x) && x > 0;


### PR DESCRIPTION
Note that [`integer?`](https://github.com/clojure/clojure/blob/clojure-1.12.2/src/clj/clojure/core.clj#L1388) returns `true` when a `BigInt` is passed to it, where as [`int?`](https://github.com/clojure/clojure/blob/clojure-1.12.2/src/clj/clojure/core.clj#L1414) returns `false`.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
