### PR TITLE
Fixed `shuffle` not working on lazy sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - [#779](https://github.com/squint-cljs/squint/pull/779): Added `compare-and-swap!`, `swap-vals!` and `reset-vals!`
 - [#788](https://github.com/squint-cljs/squint/pull/788): Fixed compilation of `dotimes` with `_` binding
+- [#790](https://github.com/squint-cljs/squint/pull/790): Fixed `shuffle` not working on lazy sequences
 - Multiple `:require-macros` with `:refer` now accumulate instead of overwriting
 
 ## v0.9.182

--- a/src/squint/core.js
+++ b/src/squint/core.js
@@ -1988,7 +1988,7 @@ export function sort_by(keyfn, comp, coll) {
 
 export function shuffle(coll) {
   const result = [...coll];
-  let remaining = coll.length;
+  let remaining = result.length;
   while (remaining) {
     const i = Math.floor(Math.random() * remaining--);
     const tmp = result[remaining];

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1653,7 +1653,8 @@ with `backticks`")))]
 (deftest shuffle-test
   (let [shuffled (jsv! '(shuffle [1 2 3 4]))]
     (doseq [i shuffled]
-      (is (contains? #{1 2 3 4} i)))))
+      (is (contains? #{1 2 3 4} i))))
+  (is (= false (jsv! '(= (vec (range 100)) (shuffle (range 100)))))))
 
 (deftest some-test
   (is (= 1 (jsv! '(some #(when (odd? %) %) [2 1 2 1])))))


### PR DESCRIPTION
```
(println (shuffle (map inc (range 10))))
; => [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

(println (shuffle (mapv inc (range 10))))
; => [2, 1, 10, 6, 5, 9, 3, 4, 8, 7]
```

Please answer the following questions and leave the below in as part of your PR.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [x] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [x] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
