### PR TITLE
Add built-in cljs.test/clojure.test support

### DIFF
--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -87,7 +87,7 @@
     (shell "node" "node_cli.js" "compile" src)
     (let [out (:out (shell {:out :string} "node" out-file))]
       (fs/delete out-file)
-      (assert (str/includes? out "Ran 6 tests containing 10 assertions") out)
+      (assert (str/includes? out "Ran 7 tests containing 13 assertions") out)
       (assert (str/includes? out "1 failures, 0 errors") out))))
 
 (defn test-squint []

--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -24,13 +24,20 @@
                                         ((requiring-resolve 'clojure.pprint/pprint)
                                          parsed)))))
 
+(defn compile-test-runtime
+  "Pre-compile the cljs.test runtime from its .cljs source so it ships in
+  the npm package and is available to local tests."
+  []
+  (shell "node" "node_cli.js" "compile" "src/squint/test.cljs"))
+
 (defn build-squint-npm-package []
   (fs/create-dirs ".work")
   (fs/delete-tree "lib")
   (fs/delete-tree ".shadow-cljs")
   (bump-core-vars)
   (spit ".work/config-merge.edn" "{}")
-  (shell "npx shadow-cljs --config-merge .work/config-merge.edn release squint"))
+  (shell "npx shadow-cljs --config-merge .work/config-merge.edn release squint")
+  (compile-test-runtime))
 
 (defn publish []
   (build-squint-npm-package)
@@ -74,15 +81,26 @@
         out (:out (shell {:dir dir :out :string} (fs/which "npx") "squint" "run" "script.cljs"))]
     (assert (str/includes? out "dude"))))
 
+(defn test-cljs-test [_]
+  (let [src "test-resources/cljs_test_smoke.cljs"
+        out-file "test-resources/cljs_test_smoke.mjs"]
+    (shell "node" "node_cli.js" "compile" src)
+    (let [out (:out (shell {:out :string} "node" out-file))]
+      (fs/delete out-file)
+      (assert (str/includes? out "Ran 4 tests containing 8 assertions") out)
+      (assert (str/includes? out "1 failures, 0 errors") out))))
+
 (defn test-squint []
   (fs/create-dirs ".work")
   (spit ".work/config-merge.edn" (shadow-extra-test-config))
   (bump-core-vars)
   (shell "npx shadow-cljs --config-merge .work/config-merge.edn compile squint")
+  (compile-test-runtime)
   (shell "node lib/squint_tests.js")
   (node-repl-tests/run-tests {})
   (test-project {})
-  (test-run {}))
+  (test-run {})
+  (test-cljs-test {}))
 
 (defn clojure-mode-test []
   (let [dir "libtests"]

--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -87,7 +87,7 @@
     (shell "node" "node_cli.js" "compile" src)
     (let [out (:out (shell {:out :string} "node" out-file))]
       (fs/delete out-file)
-      (assert (str/includes? out "Ran 7 tests containing 13 assertions") out)
+      (assert (str/includes? out "Ran 8 tests containing 17 assertions") out)
       (assert (str/includes? out "1 failures, 0 errors") out))))
 
 (defn test-squint []

--- a/bb/tasks.clj
+++ b/bb/tasks.clj
@@ -87,7 +87,7 @@
     (shell "node" "node_cli.js" "compile" src)
     (let [out (:out (shell {:out :string} "node" out-file))]
       (fs/delete out-file)
-      (assert (str/includes? out "Ran 4 tests containing 8 assertions") out)
+      (assert (str/includes? out "Ran 6 tests containing 10 assertions") out)
       (assert (str/includes? out "1 failures, 0 errors") out))))
 
 (defn test-squint []

--- a/doc/cljs-test-todo.md
+++ b/doc/cljs-test-todo.md
@@ -1,0 +1,124 @@
+# cljs.test / clojure.test: known gaps in squint's implementation
+
+This list captures behavior the squint (and cherry) cljs.test built-ins
+don't yet match against the canonical `clojure.test` / `cljs.test`. The
+ordering is rough priority — high-impact correctness gaps first, then
+extensibility gaps, then polish.
+
+## Correctness — likely to bite real users
+
+### 1. Fixtures are global, not per-namespace
+`set-each-fixtures!` / `set-once-fixtures!` write into the single global
+env. Real `clojure.test` keys fixtures by namespace (`(alter-meta! ns ...)`).
+Today, two test namespaces each calling `(use-fixtures :each ...)` will
+clobber each other; whichever loaded last wins for *every* test.
+
+**Fix sketch:** key `:each-fixtures` / `:once-fixtures` by ns string in the
+env; `core-use-fixtures` macro captures `(&env :ns :name str)` and
+includes it in the `set-*-fixtures!` call; `test-var` looks the test fn's
+ns up via the same metadata `register-test!` already attaches, then
+fetches the right fixture vector.
+
+### 2. run-tests doesn't reset counters per call
+`(run-tests)` auto-inits the env only when `*current-env*` is `nil`. A
+second `(run-tests)` in the same module reuses (and inflates) the
+existing counters. Tests that themselves invoke `run-tests` (squint and
+cherry's own runtime tests do this) emit summaries showing cumulative
+counts, not per-run counts.
+
+**Fix sketch:** snapshot counters at start, restore (or delta) before
+emitting summary. Or always init a fresh env at the top of `run-tests`
+unless the caller opts out.
+
+### 3. Quoted-symbol emission breaks `is` reporting
+The shared macro `(:name '~name)` would expand to `cljs.core.symbol(...)`
+under squint, which doesn't exist at runtime. We worked around it by
+storing `:name` as a string (and `assert-expr` uses `(pr-str form)`).
+Result: `(:name (meta test-fn))` is a string, not a symbol — diverges
+from `clojure.test`'s expectations and breaks code that calls
+`namespace`/`name` on it.
+
+**Fix sketch:** fix squint's quote emission to route through
+`squint_core.symbol` (already a real fn) instead of the literal
+`cljs.core.symbol`. Then revert macros to symbol form for parity with
+cherry/cljs.test.
+
+## Extensibility — currently impossible to extend
+
+### 4. `assert-expr` is hardcoded
+Real `clojure.test/assert-expr` is a multimethod keyed on the head of
+the form inside `(is ...)`. Users add new assertions by `defmethod`-ing
+it. Ours is a `case` over `=`, `thrown?`, `thrown-with-msg?`. No
+extension point.
+
+**Fix sketch:** make `assert-expr` a multimethod (or a registry of
+`{op-sym (fn [msg form] ...)}`) that the macro consults. Squint can ship
+the existing four cases as default methods.
+
+### 5. `report` is hardcoded too
+`clojure.test/report` is a multimethod keyed on `:type`; users add
+methods to extend reporting (e.g. cljs-test-display). Ours is a single
+`case` defn.
+
+**Fix sketch:** convert to a multimethod (works in squint's runtime; we
+already use `(use-fixtures ...)` etc.).
+
+### 6. `test-var` is a plain fn
+`clojure.test/test-var` is a multimethod (`:default` impl is what
+everyone uses, but it's overridable). Same idea as `report`.
+
+## Coverage gaps — features that exist but are partial
+
+### 7. `:begin-test-ns` / `:end-test-ns` are never emitted
+We support the report types in `report`'s `case`, but `run-tests` never
+fires them. Real `clojure.test` brackets each ns it processes with these
+events; reporters use them to group output.
+
+### 8. No `(t/async done body)` form
+Real `cljs.test` async tests use `(async done (do ... (done)))`. We use
+`^:async` on the deftest plus a Promise-returning body. Functionally
+equivalent but different surface — code copied from a CLJS project
+won't run.
+
+### 9. Test discovery is registration-based, not metadata-based
+`clojure.test/run-tests` walks `ns-publics` and filters by
+`(:test (meta var))`. We use a separate `test-registry` because squint
+has no var metadata at runtime. That works for tests defined via our
+`deftest`, but a user who manually attaches `:test true` to a defn
+won't be picked up.
+
+**Note:** unclear this is fixable without a var registry — probably
+accept the divergence and document.
+
+### 10. `successful?` reads global counters
+`(successful? results)` is meant to take the *return value* of
+`run-tests` (a counters map) and tell you if it passed. Today many of
+our internal call sites pass `(:report-counters (get-current-env))`
+which is global state. After our run-tests rewrite returns counters
+properly this is mostly fine, but the helper still reads the env when
+called with no/incompatible args.
+
+## Polish — cosmetic but worth fixing
+
+### 11. Inner `run-tests` calls produce double summary output
+Two of cherry's `cross_platform_test` cases call `run-tests` inside test
+bodies (testing the runtime itself). Each emits its own `:summary` line,
+on top of the outer test run's summary. Visual noise; not a correctness
+issue.
+
+**Fix sketch:** add a `{:summary? false}` opts arg to `run-tests`, or
+drop the auto-summary and require an explicit `(report {:type :summary})`
+at the call site (matching the very first version we had).
+
+### 12. `:report-counters :summary` increments needlessly
+`report` calls `(inc-report-counter! :type)` unconditionally, including
+for `:type :summary`. Adds a meaningless counter to the env map.
+
+### 13. No `*test-out*` redirection
+Output goes hard-wired to `js/console.log`/`js/console.error`. Real
+`cljs.test` lets users rebind via `*report-out*` or per-method.
+
+### 14. Cherry runtime and squint runtime drifted in subtle ways
+Both implement the same surface but are separate `.cljs` files. Easy to
+fix one and forget the other. Could share via a `.cljc` if we factor
+out the few JS-vs-CLJS differences.

--- a/doc/cljs-test-todo.md
+++ b/doc/cljs-test-todo.md
@@ -7,28 +7,29 @@ extensibility gaps, then polish.
 
 ## Correctness — likely to bite real users
 
-### 1. Fixtures are global, not per-namespace
-`set-each-fixtures!` / `set-once-fixtures!` write into the single global
+### 1. Fixtures are global, not per-namespace ✅ DONE
+~~`set-each-fixtures!` / `set-once-fixtures!` write into the single global
 env. Real `clojure.test` keys fixtures by namespace (`(alter-meta! ns ...)`).
 Today, two test namespaces each calling `(use-fixtures :each ...)` will
-clobber each other; whichever loaded last wins for *every* test.
+clobber each other; whichever loaded last wins for *every* test.~~
 
-**Fix sketch:** key `:each-fixtures` / `:once-fixtures` by ns string in the
-env; `core-use-fixtures` macro captures `(&env :ns :name str)` and
-includes it in the `set-*-fixtures!` call; `test-var` looks the test fn's
-ns up via the same metadata `register-test!` already attaches, then
-fetches the right fixture vector.
+Fixed: `:each-fixtures` and `:once-fixtures` are now `{ns-str → vec}`
+maps; `core-deftest` stashes `:ns` in the test fn's meta; `test-var`
+and `run-tests` look fixtures up by that ns. The 1-arg legacy setters
+target a `nil`-keyed bucket for back-compat. Regression tests in both
+the squint smoke suite and cherry's `cross_platform_test`.
 
-### 2. run-tests doesn't reset counters per call
-`(run-tests)` auto-inits the env only when `*current-env*` is `nil`. A
+### 2. run-tests doesn't reset counters per call ✅ DONE
+~~`(run-tests)` auto-inits the env only when `*current-env*` is `nil`. A
 second `(run-tests)` in the same module reuses (and inflates) the
 existing counters. Tests that themselves invoke `run-tests` (squint and
 cherry's own runtime tests do this) emit summaries showing cumulative
-counts, not per-run counts.
+counts, not per-run counts.~~
 
-**Fix sketch:** snapshot counters at start, restore (or delta) before
-emitting summary. Or always init a fresh env at the top of `run-tests`
-unless the caller opts out.
+Fixed: `run-tests` saves the caller's `:report-counters`, runs against
+fresh ones, restores on return. The returned summary map reflects only
+that run. Inner `run-tests` calls now show their own per-call summary
+instead of polluted cumulative totals. Regression tests in both repos.
 
 ### 3. Quoted-symbol emission breaks `is` reporting
 The shared macro `(:name '~name)` would expand to `cljs.core.symbol(...)`
@@ -90,25 +91,21 @@ won't be picked up.
 **Note:** unclear this is fixable without a var registry — probably
 accept the divergence and document.
 
-### 10. `successful?` reads global counters
-`(successful? results)` is meant to take the *return value* of
-`run-tests` (a counters map) and tell you if it passed. Today many of
-our internal call sites pass `(:report-counters (get-current-env))`
-which is global state. After our run-tests rewrite returns counters
-properly this is mostly fine, but the helper still reads the env when
-called with no/incompatible args.
+### 10. ~~`successful?` reads global counters~~ — non-issue
+On re-read: `successful?` takes a counters map and reads `:fail`/`:error`
+from it. No global state involved. Removed.
 
 ## Polish — cosmetic but worth fixing
 
-### 11. Inner `run-tests` calls produce double summary output
-Two of cherry's `cross_platform_test` cases call `run-tests` inside test
+### 11. Inner `run-tests` calls produce double summary output ✅ DONE
+~~Two of cherry's `cross_platform_test` cases call `run-tests` inside test
 bodies (testing the runtime itself). Each emits its own `:summary` line,
-on top of the outer test run's summary. Visual noise; not a correctness
-issue.
+on top of the outer test run's summary.~~
 
-**Fix sketch:** add a `{:summary? false}` opts arg to `run-tests`, or
-drop the auto-summary and require an explicit `(report {:type :summary})`
-at the call site (matching the very first version we had).
+Side-effect of #2: each inner `run-tests` now reports its own per-call
+summary with accurate counts (instead of cumulative pollution). Still
+multiple summary lines, but the lines are correct and informative —
+not noise. Closing.
 
 ### 12. `:report-counters :summary` increments needlessly
 `report` calls `(inc-report-counter! :type)` unconditionally, including

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "src/squint/set.js",
     "src/squint/html.js",
     "src/squint/math.js",
+    "src/squint/test.mjs",
     "lib",
     "node_cli.js",
     "index.js",
@@ -59,6 +60,7 @@
     "./src/squint/math.js": "./src/squint/math.js",
     "./src/squint/string.js": "./src/squint/string.js",
     "./node-api.js": "./node-api.js",
-    "./src/squint/html.js": "./src/squint/html.js"
+    "./src/squint/html.js": "./src/squint/html.js",
+    "./src/squint/test.mjs": "./src/squint/test.mjs"
   }
 }

--- a/playground/bb.edn
+++ b/playground/bb.edn
@@ -6,7 +6,7 @@
                   (fs/create-sym-link "public/js/squint-local" (fs/parent (fs/parent (fs/absolutize ".")))))
                 (let [squint-prod (fs/file "public" "public" "src" "squint")]
                   (fs/create-dirs squint-prod)
-                  (doseq [source-file ["core.js" "string.js" "set.js" "html.js" "math.js"]]
+                  (doseq [source-file ["core.js" "string.js" "set.js" "html.js" "math.js" "test.mjs"]]
                     (fs/copy (fs/file  ".." "src" "squint" source-file)
                              squint-prod
                              {:replace-existing true}))))}

--- a/playground/public/js/main_js.mjs
+++ b/playground/public/js/main_js.mjs
@@ -104,7 +104,10 @@ let evalCode = async (code) => {
     let js = globalThis.compilerState.javascript;
     if (dev) {
       console.log("Loading local squint libs");
-      js = js.replaceAll("'squint-cljs/", "'./squint-local/");
+      // Rewrite to absolute URLs: Blob URLs used for non-REPL eval have an
+      // opaque origin that can't resolve relative specifiers.
+      const localBase = new URL('./squint-local/', import.meta.url).href;
+      js = js.replaceAll("'squint-cljs/", `'${localBase}`);
     }
     JSEditor(js);
     if (!repl) {

--- a/playground/public/js/main_js.mjs
+++ b/playground/public/js/main_js.mjs
@@ -105,8 +105,10 @@ let evalCode = async (code) => {
     if (dev) {
       console.log("Loading local squint libs");
       // Rewrite to absolute URLs: Blob URLs used for non-REPL eval have an
-      // opaque origin that can't resolve relative specifiers.
-      const localBase = new URL('./squint-local/', import.meta.url).href;
+      // opaque origin that can't resolve relative specifiers. Anchor on the
+      // page origin — import.meta.url can point to an unexpected bundle path
+      // under Vite.
+      const localBase = `${window.location.origin}/js/squint-local/`;
       js = js.replaceAll("'squint-cljs/", `'${localBase}`);
     }
     JSEditor(js);

--- a/playground/public/js/main_js.mjs
+++ b/playground/public/js/main_js.mjs
@@ -108,10 +108,13 @@ let evalCode = async (code) => {
     }
     JSEditor(js);
     if (!repl) {
-      const encodedJs = encodeURIComponent(js);
-      const dataUri =
-        'data:text/javascript;charset=utf-8;eval=' + Date.now() + ',' + encodedJs;
-      let result = await import(/* @vite-ignore */dataUri);
+      const blob = new Blob([js], { type: 'text/javascript' });
+      const blobUrl = URL.createObjectURL(blob);
+      try {
+        let result = await import(/* @vite-ignore */blobUrl);
+      } finally {
+        URL.revokeObjectURL(blobUrl);
+      }
     } else {
       let result = await eval(`(async function() { ${js} })()`);
       if (result && result?.constructor?.name === 'LazyIterable') {

--- a/src/squint/compiler.cljc
+++ b/src/squint/compiler.cljc
@@ -24,7 +24,8 @@
    [squint.internal.fn :refer [core-defmacro core-defn core-defn- core-fn]]
    [squint.internal.loop :as loop]
    [squint.internal.macros :as macros]
-   [squint.internal.protocols :as protocols])
+   [squint.internal.protocols :as protocols]
+   [squint.internal.test :as test])
   #?(:cljs (:require-macros [squint.resource :refer [edn-resource]])))
 
 
@@ -104,6 +105,16 @@
                              'get macros/get-inline
                              'vswap! macros/vswap!}
                             cc/common-macros))
+
+(def built-in-macro-nss
+  ;; Keyed by every plausible form of the macro namespace so lookups can
+  ;; succeed whether the compiler sees the original symbol, the post-
+  ;; resolve-ns libname string, or the macro-ns returned by resolve-macro-ns.
+  (let [m test/core-test-macros]
+    {'squint.test m
+     'cljs.test m
+     'clojure.test m
+     "squint-cljs/src/squint/test.mjs" m}))
 
 (def core-config {:vars (edn-resource "squint/core.edn")})
 
@@ -242,10 +253,16 @@
                                                     (some (fn [[alias-sym alias-lib]]
                                                             (when (= (str alias-lib) resolved-ns)
                                                               (get-in ns-state [:macros alias-sym nms])))
-                                                          (:aliases current-ns-state)))))))
+                                                          (:aliases current-ns-state)))
+                                                  (get-in built-in-macro-nss [macro-ns nms])
+                                                  (get-in built-in-macro-nss [resolved-ns nms])))))
                                          (let [refers (:refers current-ns-state)]
                                            (when-let [macro-ns (get refers nms)]
-                                             (get-in ns-state [:macros macro-ns nms]))))
+                                             (or (get-in ns-state [:macros macro-ns nms])
+                                                 (let [resolved (cc/resolve-macro-ns macro-ns)]
+                                                   (or (get-in ns-state [:macros resolved nms])
+                                                       (get-in built-in-macro-nss [macro-ns nms])
+                                                       (get-in built-in-macro-nss [resolved nms])))))))
                                        ;; lazy resolve: ask SCI for transitive macro deps
                                        (when-let [resolve-macro (:resolve-macro ns-state)]
                                          (resolve-macro (or (some-> ns symbol) nms) nms))))))]

--- a/src/squint/compiler.cljc
+++ b/src/squint/compiler.cljc
@@ -254,8 +254,16 @@
                                                             (when (= (str alias-lib) resolved-ns)
                                                               (get-in ns-state [:macros alias-sym nms])))
                                                           (:aliases current-ns-state)))
-                                                  (get-in built-in-macro-nss [macro-ns nms])
-                                                  (get-in built-in-macro-nss [resolved-ns nms])))))
+                                                  ;; Built-in fallback. Only consult if the user actually
+                                                  ;; required this ns — otherwise (cljs.test/foo) with no
+                                                  ;; require would silently work. Cheaper to first see if
+                                                  ;; there's even a built-in candidate.
+                                                  (when-let [m (or (get-in built-in-macro-nss [macro-ns nms])
+                                                                   (get-in built-in-macro-nss [resolved-ns nms]))]
+                                                    (when (or (contains? (:aliases current-ns-state) nss)
+                                                              (contains? (:aliases current-ns-state)
+                                                                         (symbol (cc/alias-munge (str nss)))))
+                                                      m))))))
                                          (let [refers (:refers current-ns-state)]
                                            (when-let [macro-ns (get refers nms)]
                                              (or (get-in ns-state [:macros macro-ns nms])

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -297,7 +297,59 @@
 (defn alias-munge [s]
   (-> s str munge (str/replace #"\." "_DOT_") ))
 
-(declare resolve-ns)
+(defn resolve-import-map [import-maps lib]
+  (get import-maps lib lib))
+
+(defn resolve-macro-ns
+  "Map a runtime namespace to its macro namespace (per target).
+  The single-arg form reads *target*; pass it explicitly when the call
+  site lives inside a Promise chain where the dynamic binding has
+  already been unwound."
+  ([alias] (resolve-macro-ns alias *target*))
+  ([alias target]
+   (case target
+     :squint (case alias
+               (clojure.test cljs.test) 'squint.test
+               alias)
+     (case alias
+       (clojure.test cljs.test) 'cherry.test
+       alias))))
+
+(def ^:private builtin-test-macro-names
+  '#{deftest deftest- is testing are use-fixtures})
+
+(defn builtin-refer-is-macro?
+  "Returns true when a `:refer`'d symbol is known to be a compiler built-in
+  macro and must not be emitted as a runtime import."
+  [original-libname refer-sym]
+  (and (symbol? original-libname)
+       (contains? '#{cljs.test clojure.test cherry.test squint.test} original-libname)
+       (contains? builtin-test-macro-names refer-sym)))
+
+(defn resolve-ns [env alias]
+  (let [import-maps (:import-maps env)]
+    (case *target*
+      :squint
+      (case alias
+        (squint.string clojure.string) (resolve-import-map import-maps "squint-cljs/src/squint/string.js")
+        (squint.set clojure.set) (resolve-import-map import-maps "squint-cljs/src/squint/set.js")
+        (squint.math clojure.math cljs.math) (resolve-import-map import-maps "squint-cljs/src/squint/math.js")
+        (squint.test cljs.test clojure.test) (resolve-import-map import-maps "squint-cljs/src/squint/test.mjs")
+        (if (symbol? alias)
+          (if-let [resolve-ns (:resolve-ns env)]
+            (or (resolve-ns alias)
+                alias)
+            alias)
+          (resolve-import-map import-maps alias)))
+      :cherry
+      (case alias
+        (cljs.string clojure.string) "cherry-cljs/lib/clojure.string.js"
+        (cljs.walk clojure.walk) "cherry-cljs/lib/clojure.walk.js"
+        (cljs.set clojure.set) "cherry-cljs/lib/clojure.set.js"
+        (cljs.pprint clojure.pprint) "cherry-cljs/lib/cljs.pprint.js"
+        (cljs.test clojure.test) "cherry-cljs/lib/clojure.test.js"
+        alias)
+      alias)))
 
 (defmethod emit #?(:clj clojure.lang.Symbol :cljs Symbol) [expr env]
   (if (:quote env)
@@ -605,60 +657,6 @@
 #_(defn wrap-iife [s]
     (cond-> (format "(%sfunction () {\n %s\n})()" (if *async* "async " "") s)
       *async* (wrap-await)))
-
-(defn resolve-import-map [import-maps lib]
-  (get import-maps lib lib))
-
-(defn resolve-macro-ns
-  "Map a runtime namespace to its macro namespace (per target).
-  The single-arg form reads *target*; pass it explicitly when the call
-  site lives inside a Promise chain where the dynamic binding has
-  already been unwound."
-  ([alias] (resolve-macro-ns alias *target*))
-  ([alias target]
-   (case target
-     :squint (case alias
-               (clojure.test cljs.test) 'squint.test
-               alias)
-     (case alias
-       (clojure.test cljs.test) 'cherry.test
-       alias))))
-
-(def ^:private builtin-test-macro-names
-  '#{deftest deftest- is testing are use-fixtures})
-
-(defn builtin-refer-is-macro?
-  "Returns true when a `:refer`'d symbol is known to be a compiler built-in
-  macro and must not be emitted as a runtime import."
-  [original-libname refer-sym]
-  (and (symbol? original-libname)
-       (contains? '#{cljs.test clojure.test cherry.test squint.test} original-libname)
-       (contains? builtin-test-macro-names refer-sym)))
-
-(defn resolve-ns [env alias]
-  (let [import-maps (:import-maps env)]
-    (case *target*
-      :squint
-      (case alias
-        (squint.string clojure.string) (resolve-import-map import-maps "squint-cljs/src/squint/string.js")
-        (squint.set clojure.set) (resolve-import-map import-maps "squint-cljs/src/squint/set.js")
-        (squint.math clojure.math cljs.math) (resolve-import-map import-maps "squint-cljs/src/squint/math.js")
-        (squint.test cljs.test clojure.test) (resolve-import-map import-maps "squint-cljs/src/squint/test.mjs")
-        (if (symbol? alias)
-          (if-let [resolve-ns (:resolve-ns env)]
-            (or (resolve-ns alias)
-                alias)
-            alias)
-          (resolve-import-map import-maps alias)))
-      :cherry
-      (case alias
-        (cljs.string clojure.string) "cherry-cljs/lib/clojure.string.js"
-        (cljs.walk clojure.walk) "cherry-cljs/lib/clojure.walk.js"
-        (cljs.set clojure.set) "cherry-cljs/lib/clojure.set.js"
-        (cljs.pprint clojure.pprint) "cherry-cljs/lib/cljs.pprint.js"
-        (cljs.test clojure.test) "cherry-cljs/lib/clojure.test.js"
-        alias)
-      alias)))
 
 (defn unwrap [s]
   (str/replace (str s) #"^\(|\)$" ""))

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -362,11 +362,12 @@
                                      (when-let [imports (:imports env)]
                                        (swap! imports str
                                               (if *repl*
-                                                (str (statement (format "var %s = await import('%s')" auto-alias resolved))
-                                                     ;; match the ns form's pattern: expose the import on the ns object
-                                                     ;; so later globalThis.<ns>.<auto-alias> refs resolve.
-                                                     (statement (format "globalThis.%s.%s = %s"
-                                                                        (munge *cljs-ns*) auto-alias auto-alias)))
+                                                (let [mns (munge *cljs-ns*)]
+                                                  (str (statement (format "var %s = await import('%s')" auto-alias resolved))
+                                                       ;; ensure the ns object exists before assigning onto it — the ns
+                                                       ;; form also emits this guard, but our auto-import may land first.
+                                                       (statement (format "globalThis.%s = globalThis.%s || {}" mns mns))
+                                                       (statement (format "globalThis.%s.%s = %s" mns auto-alias auto-alias))))
                                                 (statement (format "import * as %s from '%s'" auto-alias resolved)))))
                                      (swap! *imported-vars* update (str resolved) (fnil identity #{}))
                                      (swap! (:ns-state env)

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -297,6 +297,8 @@
 (defn alias-munge [s]
   (-> s str munge (str/replace #"\." "_DOT_") ))
 
+(declare resolve-ns)
+
 (defmethod emit #?(:clj clojure.lang.Symbol :cljs Symbol) [expr env]
   (if (:quote env)
     (emit-return (escape-jsx (emit (list 'cljs.core/symbol
@@ -347,8 +349,15 @@
                                  nm (name expr)
                                  ;; auto-import: if ns resolves to a file, generate import on the fly
                                  auto-alias (alias-munge ns)
-                                 resolved (when-let [resolve-ns (:resolve-ns env)]
-                                            (resolve-ns (symbol ns)))
+                                 resolved (or (when-let [rns (:resolve-ns env)]
+                                                (rns (symbol ns)))
+                                              ;; fall back to the built-in ns->libname mapping
+                                              ;; so macro-generated qualified refs to e.g. cljs.test
+                                              ;; get an auto-import in squint output.
+                                              (let [r (resolve-ns env (symbol ns))]
+                                                (when (and (string? r)
+                                                           (not= r (str (symbol ns))))
+                                                  r)))
                                  _ (when (and resolved (not (contains? aliases (symbol auto-alias))))
                                      (when-let [imports (:imports env)]
                                        (swap! imports str
@@ -596,11 +605,26 @@
   (get import-maps lib lib))
 
 (defn resolve-macro-ns
-  "For cherry: map a runtime namespace to its macro namespace."
+  "Map a runtime namespace to its macro namespace (per target)."
   [alias]
-  (case alias
-    (clojure.test cljs.test) 'cherry.test
-    alias))
+  (case *target*
+    :squint (case alias
+              (clojure.test cljs.test) 'squint.test
+              alias)
+    (case alias
+      (clojure.test cljs.test) 'cherry.test
+      alias)))
+
+(def ^:private builtin-test-macro-names
+  '#{deftest deftest- is testing are use-fixtures})
+
+(defn builtin-refer-is-macro?
+  "Returns true when a `:refer`'d symbol is known to be a compiler built-in
+  macro and must not be emitted as a runtime import."
+  [original-libname refer-sym]
+  (and (symbol? original-libname)
+       (contains? '#{cljs.test clojure.test cherry.test squint.test} original-libname)
+       (contains? builtin-test-macro-names refer-sym)))
 
 (defn resolve-ns [env alias]
   (let [import-maps (:import-maps env)]
@@ -610,6 +634,7 @@
         (squint.string clojure.string) (resolve-import-map import-maps "squint-cljs/src/squint/string.js")
         (squint.set clojure.set) (resolve-import-map import-maps "squint-cljs/src/squint/set.js")
         (squint.math clojure.math cljs.math) (resolve-import-map import-maps "squint-cljs/src/squint/math.js")
+        (squint.test cljs.test clojure.test) (resolve-import-map import-maps "squint-cljs/src/squint/test.mjs")
         (if (symbol? alias)
           (if-let [resolve-ns (:resolve-ns env)]
             (or (resolve-ns alias)
@@ -711,51 +736,53 @@
                                                                        (get rename refer refer)) refer)
                                                                (repeat (if (symbol? original-libname)
                                                                          original-libname libname)))))))))
-                  (str
-                    (let [referred+renamed (str/join ", "
-                                                     (map (fn [refer]
-                                                            (str (munge refer)
-                                                                 (when-let [renamed (get rename refer)]
-                                                                   (str " as " (munge renamed)))))
-                                                          refer))]
-                      (if *repl*
-                        (str (statement (format "var { %s } = (await import ('%s'%s))%s" (str/replace referred+renamed " as " ": ") libname
-                                                (if with
-                                                  (str ", " (emit {:with with} env))
-                                                  "")
-                                                (if suffix
-                                                  (str "." suffix)
-                                                  "")))
-                             (str/join (map (fn [sym]
-                                              (let [sym (munge sym)]
-                                                (statement (str "globalThis." (munge current-ns-name) "." sym " = " sym))))
-                                            (map (fn [refer]
-                                                   (get rename refer refer))
-                                                 refer))))
+                  (let [runtime-refer (remove #(builtin-refer-is-macro? original-libname %) refer)]
+                    (str
+                      (when (seq runtime-refer)
+                        (let [referred+renamed (str/join ", "
+                                                         (map (fn [refer]
+                                                                (str (munge refer)
+                                                                     (when-let [renamed (get rename refer)]
+                                                                       (str " as " (munge renamed)))))
+                                                              runtime-refer))]
+                          (if *repl*
+                            (str (statement (format "var { %s } = (await import ('%s'%s))%s" (str/replace referred+renamed " as " ": ") libname
+                                                    (if with
+                                                      (str ", " (emit {:with with} env))
+                                                      "")
+                                                    (if suffix
+                                                      (str "." suffix)
+                                                      "")))
+                                 (str/join (map (fn [sym]
+                                                  (let [sym (munge sym)]
+                                                    (statement (str "globalThis." (munge current-ns-name) "." sym " = " sym))))
+                                                (map (fn [refer]
+                                                       (get rename refer refer))
+                                                     runtime-refer))))
 
-                        (if default?
-                          (let [libname* ((:gensym env) "default")]
-                            (str (statement (format "import %s from '%s'%s" libname* libname (if with
-                                                                                               (str " with " (unwrap (emit with env)))
-                                                                                               "")))
-                                 (statement (format "const { %s } = %s" referred+renamed libname*))))
-                          (statement (format "import { %s } from '%s'%s" referred+renamed libname (if with
-                                                                                                    (str " with " (unwrap (emit with env)))
-                                                                                                    ""))))))
-                    ;; for symbol requires with :refer but no :as, also generate namespace import
-                    ;; so qualified refs from macro expansions resolve
-                    (when (and (not as) (symbol? original-libname))
-                      (let [auto-alias (alias-munge (str original-libname))]
-                        (swap! *imported-vars* update libname (fnil identity #{}))
-                        (if *repl*
-                          (statement (format "var %s = await import('%s'%s)" auto-alias libname
-                                             (if with
-                                               (str ", " (emit {:with with} env))
-                                               "")))
-                          (statement (format "import * as %s from '%s'%s" auto-alias libname
-                                             (if with
-                                               (str " with " (unwrap (emit with env)))
-                                               "")))))))))]
+                            (if default?
+                              (let [libname* ((:gensym env) "default")]
+                                (str (statement (format "import %s from '%s'%s" libname* libname (if with
+                                                                                                   (str " with " (unwrap (emit with env)))
+                                                                                                   "")))
+                                     (statement (format "const { %s } = %s" referred+renamed libname*))))
+                              (statement (format "import { %s } from '%s'%s" referred+renamed libname (if with
+                                                                                                        (str " with " (unwrap (emit with env)))
+                                                                                                        "")))))))
+                      ;; for symbol requires with :refer but no :as, also generate namespace import
+                      ;; so qualified refs from macro expansions resolve
+                      (when (and (not as) (symbol? original-libname))
+                        (let [auto-alias (alias-munge (str original-libname))]
+                          (swap! *imported-vars* update libname (fnil identity #{}))
+                          (if *repl*
+                            (statement (format "var %s = await import('%s'%s)" auto-alias libname
+                                               (if with
+                                                 (str ", " (emit {:with with} env))
+                                                 "")))
+                            (statement (format "import * as %s from '%s'%s" auto-alias libname
+                                               (if with
+                                                 (str " with " (unwrap (emit with env)))
+                                                 ""))))))))))]
       (when (or as (symbol? original-libname))
         (swap! (:ns-state env)
                (fn [ns-state]

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -610,15 +610,19 @@
   (get import-maps lib lib))
 
 (defn resolve-macro-ns
-  "Map a runtime namespace to its macro namespace (per target)."
-  [alias]
-  (case *target*
-    :squint (case alias
-              (clojure.test cljs.test) 'squint.test
-              alias)
-    (case alias
-      (clojure.test cljs.test) 'cherry.test
-      alias)))
+  "Map a runtime namespace to its macro namespace (per target).
+  The single-arg form reads *target*; pass it explicitly when the call
+  site lives inside a Promise chain where the dynamic binding has
+  already been unwound."
+  ([alias] (resolve-macro-ns alias *target*))
+  ([alias target]
+   (case target
+     :squint (case alias
+               (clojure.test cljs.test) 'squint.test
+               alias)
+     (case alias
+       (clojure.test cljs.test) 'cherry.test
+       alias))))
 
 (def ^:private builtin-test-macro-names
   '#{deftest deftest- is testing are use-fixtures})

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -362,7 +362,11 @@
                                      (when-let [imports (:imports env)]
                                        (swap! imports str
                                               (if *repl*
-                                                (statement (format "var %s = await import('%s')" auto-alias resolved))
+                                                (str (statement (format "var %s = await import('%s')" auto-alias resolved))
+                                                     ;; match the ns form's pattern: expose the import on the ns object
+                                                     ;; so later globalThis.<ns>.<auto-alias> refs resolve.
+                                                     (statement (format "globalThis.%s.%s = %s"
+                                                                        (munge *cljs-ns*) auto-alias auto-alias)))
                                                 (statement (format "import * as %s from '%s'" auto-alias resolved)))))
                                      (swap! *imported-vars* update (str resolved) (fnil identity #{}))
                                      (swap! (:ns-state env)

--- a/src/squint/core.js
+++ b/src/squint/core.js
@@ -2500,15 +2500,10 @@ export function meta(x) {
   } else return null;
 }
 
-export const IWithMeta__withMeta = Symbol('IWithMeta__withMeta');
-
 export function with_meta(x, m) {
-  // Symbol-keyed protocol dispatch, following the IApply__apply pattern:
-  // any object can opt in by implementing this symbol method.
-  const impl = x && x[IWithMeta__withMeta];
-  if (impl) return impl.call(x, m);
-  // Default for functions: wrap in a new callable that forwards to the
-  // original, so fn? stays true and the original isn't mutated.
+  // For functions, wrap in a new callable that forwards to the original
+  // so fn? stays true and the original isn't mutated. copy() can't handle
+  // functions — a {...x} spread loses the call signature.
   if (typeof x === 'function') {
     const wrapped = function (...args) { return x.apply(this, args); };
     wrapped[_metaSym] = m;

--- a/src/squint/core.js
+++ b/src/squint/core.js
@@ -2500,7 +2500,20 @@ export function meta(x) {
   } else return null;
 }
 
+export const IWithMeta__withMeta = Symbol('IWithMeta__withMeta');
+
 export function with_meta(x, m) {
+  // Symbol-keyed protocol dispatch, following the IApply__apply pattern:
+  // any object can opt in by implementing this symbol method.
+  const impl = x && x[IWithMeta__withMeta];
+  if (impl) return impl.call(x, m);
+  // Default for functions: wrap in a new callable that forwards to the
+  // original, so fn? stays true and the original isn't mutated.
+  if (typeof x === 'function') {
+    const wrapped = function (...args) { return x.apply(this, args); };
+    wrapped[_metaSym] = m;
+    return wrapped;
+  }
   const ret = copy(x);
   ret[_metaSym] = m;
   return ret;

--- a/src/squint/internal/test.cljc
+++ b/src/squint/internal/test.cljc
@@ -53,12 +53,15 @@
                                 ~(report :fail (pr-str form) e-sym false)))))
       default)))
 
-(defn core-deftest [_&form _&env name & body]
+(defn core-deftest [_&form &env name & body]
   (let [fn-meta (select-keys (meta name) [:async])
-        fsym (gensym "fn")]
+        fsym (gensym "fn")
+        ns-name (some-> &env :ns :name str)]
     `(def ~(vary-meta name assoc :test true)
        (let [~fsym ~(with-meta `(fn [] ~@body) fn-meta)]
          (set! (.-_squintTestName ~fsym) ~(str name))
+         ~@(when ns-name
+             [`(clojure.test/register-test! ~ns-name ~fsym)])
          ~fsym))))
 
 (defn core-is
@@ -95,10 +98,22 @@
     :once `(clojure.test/set-once-fixtures! [~@fns])
     :each `(clojure.test/set-each-fixtures! [~@fns])))
 
+(defn core-run-tests [_&form &env & args]
+  ;; Match cljs.test: with no args, default to the compile-time current ns.
+  ;; The :squint.compiler/skip-macro meta stops the emission from landing back
+  ;; in this macro's lookup (which shares the name with the runtime fn).
+  (let [ns-name (some-> &env :ns :name str)
+        args' (if (and ns-name (empty? args))
+                [ns-name]
+                args)]
+    (with-meta `(clojure.test/run-tests ~@args')
+               {:squint.compiler/skip-macro true})))
+
 (def core-test-macros
   {'deftest core-deftest
    'deftest- core-deftest-
    'is core-is
    'testing core-testing
    'are core-are
-   'use-fixtures core-use-fixtures})
+   'use-fixtures core-use-fixtures
+   'run-tests core-run-tests})

--- a/src/squint/internal/test.cljc
+++ b/src/squint/internal/test.cljc
@@ -57,7 +57,7 @@
   (let [fn-meta (select-keys (meta name) [:async])
         ns-name (some-> &env :ns :name str)
         fn-form (with-meta `(fn [] ~@body) fn-meta)
-        wrapped `(with-meta ~fn-form {:name ~(str name)})]
+        wrapped `(with-meta ~fn-form {:name ~(str name) :ns ~ns-name})]
     `(def ~(vary-meta name assoc :test true)
        ~(if ns-name
           `(clojure.test/register-test! ~ns-name ~wrapped)
@@ -92,10 +92,11 @@
     `(do ~@(for [arg-group (partition binding-count args)]
              `(clojure.test/is (let [~@(interleave bindings arg-group)] ~expr))))))
 
-(defn core-use-fixtures [_&form _&env type & fns]
-  (case type
-    :once `(clojure.test/set-once-fixtures! [~@fns])
-    :each `(clojure.test/set-each-fixtures! [~@fns])))
+(defn core-use-fixtures [_&form &env type & fns]
+  (let [ns-name (some-> &env :ns :name str)]
+    (case type
+      :once `(clojure.test/set-once-fixtures! ~ns-name [~@fns])
+      :each `(clojure.test/set-each-fixtures! ~ns-name [~@fns]))))
 
 (defn core-run-tests [_&form &env & args]
   ;; Match cljs.test: with no args, default to the compile-time current ns.

--- a/src/squint/internal/test.cljc
+++ b/src/squint/internal/test.cljc
@@ -1,0 +1,104 @@
+(ns squint.internal.test)
+
+(defn assert-expr [msg form]
+  (let [op (when (sequential? form) (first form))
+        loc (meta form)
+        line (:line loc)
+        column (:column loc)
+        report (fn [type expected actual ret]
+                 `(do (clojure.test/report {:type ~type :message ~msg :expected ~expected :actual ~actual
+                                            ~@(when line [:line line])
+                                            ~@(when column [:column column])})
+                      ~ret))
+        default (let [sym (gensym "value")]
+                  `(let [~sym ~form]
+                     (if ~sym
+                       ~(report :pass (pr-str form) sym sym)
+                       ~(report :fail (pr-str form) sym sym))))]
+    (case op
+      = (if (= 2 (count (rest form)))
+          (let [[expected actual] (rest form)
+                expected-sym (gensym "expected")
+                actual-sym (gensym "actual")
+                result-sym (gensym "result")]
+            `(let [~expected-sym ~expected
+                   ~actual-sym ~actual
+                   ~result-sym (= ~expected-sym ~actual-sym)]
+               (if ~result-sym
+                 ~(report :pass expected-sym actual-sym true)
+                 ~(report :fail expected-sym actual-sym false))))
+          default)
+      thrown? (let [klass (second form)
+                    body (nthnext form 2)
+                    e-sym (gensym "e")]
+                `(try
+                   (do ~@body)
+                   ~(report :fail (pr-str form) "No exception thrown" false)
+                   (catch :default ~e-sym
+                     (if (instance? ~klass ~e-sym)
+                       ~(report :pass (pr-str form) e-sym true)
+                       ~(report :fail (pr-str form) e-sym false)))))
+      thrown-with-msg? (let [klass (second form)
+                             re (nth form 2)
+                             body (nthnext form 3)
+                             e-sym (gensym "e")]
+                         `(try
+                            (do ~@body)
+                            ~(report :fail (pr-str form) "No exception thrown" false)
+                            (catch :default ~e-sym
+                              (if (instance? ~klass ~e-sym)
+                                (if (re-find ~re (.-message ~e-sym))
+                                  ~(report :pass (pr-str form) e-sym true)
+                                  ~(report :fail (pr-str form) `(str "Exception message \"" (.-message ~e-sym) "\" did not match " ~re) false))
+                                ~(report :fail (pr-str form) e-sym false)))))
+      default)))
+
+(defn core-deftest [_&form _&env name & body]
+  (let [fn-meta (select-keys (meta name) [:async])
+        fsym (gensym "fn")]
+    `(def ~(vary-meta name assoc :test true)
+       (let [~fsym ~(with-meta `(fn [] ~@body) fn-meta)]
+         (set! (.-_squintTestName ~fsym) ~(str name))
+         ~fsym))))
+
+(defn core-is
+  ([&form &env form] (core-is &form &env form nil))
+  ([&form _&env form msg]
+   (let [loc (meta &form)
+         form-with-meta (if (and loc (or (sequential? form) (symbol? form)))
+                          (with-meta form loc)
+                          form)]
+     (assert-expr msg form-with-meta))))
+
+(defn core-testing [_&form _&env string & body]
+  `(do
+     (clojure.test/update-current-env! [:testing-contexts] conj ~string)
+     (try
+       ~@body
+       (finally
+         (clojure.test/update-current-env! [:testing-contexts] rest)))))
+
+(defn core-deftest- [&form &env name & body]
+  (apply core-deftest &form &env (vary-meta name assoc :private true) body))
+
+(defn core-are [_&form _&env bindings expr & args]
+  (assert (pos? (count bindings)) "are requires at least one binding")
+  (assert (seq args) "are requires at least one test case")
+  (let [binding-count (count bindings)]
+    (assert (zero? (mod (count args) binding-count))
+            (str "are: arg count (" (count args) ") must be divisible by binding count (" binding-count ")"))
+    `(do ~@(for [arg-group (partition binding-count args)]
+             `(clojure.test/is (let [~@(interleave bindings arg-group)] ~expr))))))
+
+(defn core-use-fixtures [_&form _&env type & fns]
+  (case type
+    :once `(clojure.test/set-once-fixtures! [~@fns])
+    :each `(clojure.test/set-each-fixtures! [~@fns])))
+
+(def core-test-macros
+  {'deftest core-deftest
+   'deftest- core-deftest-
+   'is core-is
+   'testing core-testing
+   'are core-are
+   'use-fixtures core-use-fixtures})

--- a/src/squint/internal/test.cljc
+++ b/src/squint/internal/test.cljc
@@ -55,14 +55,13 @@
 
 (defn core-deftest [_&form &env name & body]
   (let [fn-meta (select-keys (meta name) [:async])
-        fsym (gensym "fn")
-        ns-name (some-> &env :ns :name str)]
+        ns-name (some-> &env :ns :name str)
+        fn-form (with-meta `(fn [] ~@body) fn-meta)
+        wrapped `(with-meta ~fn-form {:name ~(str name)})]
     `(def ~(vary-meta name assoc :test true)
-       (let [~fsym ~(with-meta `(fn [] ~@body) fn-meta)]
-         (set! (.-_squintTestName ~fsym) ~(str name))
-         ~@(when ns-name
-             [`(clojure.test/register-test! ~ns-name ~fsym)])
-         ~fsym))))
+       ~(if ns-name
+          `(clojure.test/register-test! ~ns-name ~wrapped)
+          wrapped))))
 
 (defn core-is
   ([&form &env form] (core-is &form &env form nil))

--- a/src/squint/test.cljs
+++ b/src/squint/test.cljs
@@ -7,8 +7,8 @@
   {:report-counters {:test 0 :pass 0 :fail 0 :error 0}
    :testing-vars ()
    :testing-contexts ()
-   :once-fixtures []
-   :each-fixtures []})
+   :once-fixtures {}
+   :each-fixtures {}})
 
 (defn get-current-env []
   (or *current-env* (empty-env)))
@@ -100,22 +100,35 @@
 (defn join-fixtures [fixtures]
   (reduce compose-fixtures (fn [f] (f)) fixtures))
 
-(defn get-each-fixtures []
-  (get-in (get-current-env) [:each-fixtures] []))
+(defn get-each-fixtures
+  "Returns the each-fixture vector for ns-str, or [] if none. The 1-arg
+  variant defaults to the nil-keyed bucket, used for direct calls that
+  predate per-ns fixtures."
+  ([] (get-each-fixtures nil))
+  ([ns-str] (get-in (get-current-env) [:each-fixtures ns-str] [])))
 
-(defn set-each-fixtures! [fixtures]
-  (update-current-env! [:each-fixtures] (constantly fixtures)))
+(defn set-each-fixtures!
+  ([fixtures] (set-each-fixtures! nil fixtures))
+  ([ns-str fixtures]
+   (update-current-env! [:each-fixtures ns-str] (constantly fixtures))))
 
-(defn get-once-fixtures []
-  (get-in (get-current-env) [:once-fixtures] []))
+(defn get-once-fixtures
+  ([] (get-once-fixtures nil))
+  ([ns-str] (get-in (get-current-env) [:once-fixtures ns-str] [])))
 
-(defn set-once-fixtures! [fixtures]
-  (update-current-env! [:once-fixtures] (constantly fixtures)))
+(defn set-once-fixtures!
+  ([fixtures] (set-once-fixtures! nil fixtures))
+  ([ns-str fixtures]
+   (update-current-env! [:once-fixtures ns-str] (constantly fixtures))))
 
 (defn test-var [v]
   (when (fn? v)
     (let [test-name (or (:name (meta v)) "anonymous")
-          each-fixtures (get-each-fixtures)
+          ns-str (:ns (meta v))
+          ;; Per-ns each-fixtures, falling back to the nil-keyed bucket
+          ;; for fixtures set via the 1-arg legacy form.
+          each-fixtures (let [per-ns (get-each-fixtures ns-str)]
+                          (if (seq per-ns) per-ns (get-each-fixtures)))
           wrapped-test (if (seq each-fixtures)
                          (fn [] ((join-fixtures each-fixtures) v))
                          v)
@@ -151,13 +164,30 @@
   ([] (vec (mapcat vals (vals @test-registry))))
   ([ns-str] (vec (vals (get @test-registry ns-str)))))
 
+(defn- run-vars-with-once-fixtures [ns-str vars]
+  (let [per-ns (get-once-fixtures ns-str)
+        once-fixtures (if (seq per-ns) per-ns (get-once-fixtures))
+        run-all (fn []
+                  (reduce
+                   (fn [chain v]
+                     (if (async? chain)
+                       (.then chain (fn [_] (test-var v)))
+                       (test-var v)))
+                   nil
+                   vars))]
+    (if (seq once-fixtures)
+      ((join-fixtures once-fixtures) run-all)
+      (run-all))))
+
 (defn run-tests
   "Runs tests and reports a summary. Accepts any of:
    - no args: run every registered test across all namespaces.
    - namespace name strings: run tests registered under each given ns.
    - explicit test fns: run those fns directly.
-   Initializes the env if none is set. Returns (or resolves to, for async
-   tests) the :report-counters summary map."
+   Initializes the env if none is set. Tests are grouped by their ns
+   (from deftest's metadata) so each ns's once-fixtures wrap that ns's
+   tests, matching cljs.test. Returns (or resolves to, for async tests)
+   the :report-counters summary map."
   [& args]
   (let [test-vars (cond
                     (empty? args)
@@ -167,21 +197,21 @@
                     :else
                     args)
         _ (when (nil? *current-env*) (set-env! (empty-env)))
-        once-fixtures (get-once-fixtures)
-        run-all (fn []
-                  (reduce
-                   (fn [chain v]
-                     (if (async? chain)
-                       (.then chain (fn [_] (test-var v)))
-                       (test-var v)))
-                   nil
-                   test-vars))
+        ;; preserve insertion order while grouping by ns
+        groups (reduce (fn [acc v]
+                         (let [k (:ns (meta v))]
+                           (update acc k (fnil conj []) v)))
+                       {} test-vars)
+        run-groups (fn []
+                     (reduce (fn [chain [ns-str vars]]
+                               (if (async? chain)
+                                 (.then chain (fn [_] (run-vars-with-once-fixtures ns-str vars)))
+                                 (run-vars-with-once-fixtures ns-str vars)))
+                             nil groups))
         finish (fn [_]
                  (report {:type :summary})
                  (:report-counters (get-current-env)))
-        chain (if (seq once-fixtures)
-                ((join-fixtures once-fixtures) run-all)
-                (run-all))]
+        chain (run-groups)]
     (if (async? chain)
       (.then chain finish)
       (finish nil))))

--- a/src/squint/test.cljs
+++ b/src/squint/test.cljs
@@ -48,7 +48,8 @@
       :else "test")))
 
 (defn report [{:keys [type message expected actual line column file] :as m}]
-  (inc-report-counter! type)
+  (when (contains? #{:pass :fail :error} type)
+    (inc-report-counter! type))
   (let [location (when (or line column file)
                    (str (when file (str file ":"))
                         (when line line)

--- a/src/squint/test.cljs
+++ b/src/squint/test.cljs
@@ -179,6 +179,8 @@
       ((join-fixtures once-fixtures) run-all)
       (run-all))))
 
+(def ^:private fresh-counters {:test 0 :pass 0 :fail 0 :error 0})
+
 (defn run-tests
   "Runs tests and reports a summary. Accepts any of:
    - no args: run every registered test across all namespaces.
@@ -186,8 +188,15 @@
    - explicit test fns: run those fns directly.
    Initializes the env if none is set. Tests are grouped by their ns
    (from deftest's metadata) so each ns's once-fixtures wrap that ns's
-   tests, matching cljs.test. Returns (or resolves to, for async tests)
-   the :report-counters summary map."
+   tests, matching cljs.test.
+
+   Counters are scoped to this call: the caller's :report-counters are
+   saved on entry and restored before return, so an inner run-tests
+   doesn't pollute an outer run's totals (matches clojure.test, where
+   *report-counters* is rebound per test-ns).
+
+   Returns (or resolves to, for async tests) the :report-counters
+   summary map for this run."
   [& args]
   (let [test-vars (cond
                     (empty? args)
@@ -197,6 +206,8 @@
                     :else
                     args)
         _ (when (nil? *current-env*) (set-env! (empty-env)))
+        saved-counters (:report-counters (get-current-env))
+        _ (update-current-env! [:report-counters] (constantly fresh-counters))
         ;; preserve insertion order while grouping by ns
         groups (reduce (fn [acc v]
                          (let [k (:ns (meta v))]
@@ -210,7 +221,9 @@
                              nil groups))
         finish (fn [_]
                  (report {:type :summary})
-                 (:report-counters (get-current-env)))
+                 (let [counters (:report-counters (get-current-env))]
+                   (update-current-env! [:report-counters] (constantly saved-counters))
+                   counters))
         chain (run-groups)]
     (if (async? chain)
       (.then chain finish)

--- a/src/squint/test.cljs
+++ b/src/squint/test.cljs
@@ -114,7 +114,7 @@
 
 (defn test-var [v]
   (when (fn? v)
-    (let [test-name (or (.-_squintTestName v) (:name (meta v)) "anonymous")
+    (let [test-name (or (:name (meta v)) "anonymous")
           each-fixtures (get-each-fixtures)
           wrapped-test (if (seq each-fixtures)
                          (fn [] ((join-fixtures each-fixtures) v))
@@ -141,7 +141,7 @@
   "Registers a deftest fn under its namespace for later discovery by run-tests.
   Idempotent: re-registration replaces the previous fn with the same name."
   [ns-str test-fn]
-  (let [test-name (.-_squintTestName test-fn)]
+  (let [test-name (:name (meta test-fn))]
     (swap! test-registry assoc-in [ns-str test-name] test-fn))
   test-fn)
 

--- a/src/squint/test.cljs
+++ b/src/squint/test.cljs
@@ -1,0 +1,152 @@
+(ns squint.test
+  (:require [clojure.string]))
+
+(def ^:dynamic *current-env* nil)
+
+(defn empty-env []
+  {:report-counters {:test 0 :pass 0 :fail 0 :error 0}
+   :testing-vars ()
+   :testing-contexts ()
+   :once-fixtures []
+   :each-fixtures []})
+
+(defn get-current-env []
+  (or *current-env* (empty-env)))
+
+(defn set-env! [env]
+  (set! *current-env* env)
+  env)
+
+(defn clear-env! []
+  (set! *current-env* nil)
+  nil)
+
+(defn update-current-env! [ks f & args]
+  (let [env (get-current-env)
+        new-env (apply update-in env ks f args)]
+    (set-env! new-env)))
+
+(defn testing-contexts-str []
+  (when-let [contexts (seq (:testing-contexts (get-current-env)))]
+    (clojure.string/join " " (reverse contexts))))
+
+(defn testing-vars-str []
+  (when-let [vars (seq (:testing-vars (get-current-env)))]
+    (clojure.string/join " " (map str vars))))
+
+(defn inc-report-counter! [name]
+  (when (:report-counters (get-current-env))
+    (update-current-env! [:report-counters name] (fnil inc 0))))
+
+(defn current-test-str []
+  (let [vars (testing-vars-str)
+        ctx (testing-contexts-str)]
+    (cond
+      (and vars ctx) (str vars " " ctx)
+      vars vars
+      ctx ctx
+      :else "test")))
+
+(defn report [{:keys [type message expected actual line column file] :as m}]
+  (inc-report-counter! type)
+  (let [location (when (or line column file)
+                   (str (when file (str file ":"))
+                        (when line line)
+                        (when column (str ":" column))))]
+    (case type
+      :pass nil
+      :fail (do
+              (js/console.error (str "FAIL in " (current-test-str)
+                                     (when location (str " (" location ")"))))
+              (when message (js/console.error "  " message))
+              (js/console.error "  expected:" (pr-str expected))
+              (js/console.error "    actual:" (pr-str actual)))
+      :error (do
+               (js/console.error (str "ERROR in " (current-test-str)
+                                      (when location (str " (" location ")"))))
+               (when message (js/console.error "  " message))
+               (when expected (js/console.error "  expected:" (pr-str expected)))
+               (js/console.error "    actual:" (pr-str actual)))
+      :begin-test-ns (js/console.log "\nTesting" (str (:ns m)))
+      :end-test-ns nil
+      :begin-test-var nil
+      :end-test-var nil
+      :summary (let [{:keys [test pass fail error]} (:report-counters (get-current-env))]
+                 (js/console.log "\nRan" test "tests containing" (+ pass fail error) "assertions.")
+                 (js/console.log (str fail) "failures," (str error) "errors."))
+      (js/console.log "Unknown report type:" type m))))
+
+(defn successful? [results]
+  (and (zero? (:fail results 0))
+       (zero? (:error results 0))))
+
+(defn async? [x]
+  (instance? js/Promise x))
+
+(defn wrap-async
+  "Wraps setup/teardown fns into async-aware fixture.
+  Teardown waits for Promise resolution if test is async."
+  [setup teardown]
+  (fn [test-fn]
+    (setup)
+    (let [result (test-fn)]
+      (if (async? result)
+        (.finally result teardown)
+        (do (teardown) result)))))
+
+(defn compose-fixtures [f1 f2]
+  (fn [g] (f1 (fn [] (f2 g)))))
+
+(defn join-fixtures [fixtures]
+  (reduce compose-fixtures (fn [f] (f)) fixtures))
+
+(defn get-each-fixtures []
+  (get-in (get-current-env) [:each-fixtures] []))
+
+(defn set-each-fixtures! [fixtures]
+  (update-current-env! [:each-fixtures] (constantly fixtures)))
+
+(defn get-once-fixtures []
+  (get-in (get-current-env) [:once-fixtures] []))
+
+(defn set-once-fixtures! [fixtures]
+  (update-current-env! [:once-fixtures] (constantly fixtures)))
+
+(defn test-var [v]
+  (when (fn? v)
+    (let [test-name (or (.-_squintTestName v) (:name (meta v)) "anonymous")
+          each-fixtures (get-each-fixtures)
+          wrapped-test (if (seq each-fixtures)
+                         (fn [] ((join-fixtures each-fixtures) v))
+                         v)
+          pop-test-name! #(update-current-env! [:testing-vars] rest)]
+      (update-current-env! [:testing-vars] conj test-name)
+      (inc-report-counter! :test)
+      (try
+        (let [result (wrapped-test)]
+          (if (async? result)
+            (-> result
+                (.then (fn [r] (pop-test-name!) r))
+                (.catch (fn [e]
+                          (report {:type :error :message (.-message e) :expected nil :actual e})
+                          (pop-test-name!))))
+            (do (pop-test-name!) result)))
+        (catch :default e
+          (pop-test-name!)
+          (report {:type :error :message (.-message e) :expected nil :actual e}))))))
+
+(defn run-tests
+  "Runs test-vars with once-fixtures. Returns Promise if any test is async."
+  [& test-vars]
+  (let [once-fixtures (get-once-fixtures)
+        run-all (fn []
+                  (reduce
+                   (fn [chain v]
+                     (if (async? chain)
+                       (.then chain (fn [_] (test-var v)))
+                       (test-var v)))
+                   nil
+                   test-vars))]
+    (if (seq once-fixtures)
+      ((join-fixtures once-fixtures) run-all)
+      (run-all))))

--- a/src/squint/test.cljs
+++ b/src/squint/test.cljs
@@ -135,10 +135,39 @@
           (pop-test-name!)
           (report {:type :error :message (.-message e) :expected nil :actual e}))))))
 
+(def ^:private test-registry (atom {}))
+
+(defn register-test!
+  "Registers a deftest fn under its namespace for later discovery by run-tests.
+  Idempotent: re-registration replaces the previous fn with the same name."
+  [ns-str test-fn]
+  (let [test-name (.-_squintTestName test-fn)]
+    (swap! test-registry assoc-in [ns-str test-name] test-fn))
+  test-fn)
+
+(defn registered-tests
+  "Returns a vector of test fns registered for the given namespace name.
+  With no argument, returns all registered tests across every namespace."
+  ([] (vec (mapcat vals (vals @test-registry))))
+  ([ns-str] (vec (vals (get @test-registry ns-str)))))
+
 (defn run-tests
-  "Runs test-vars with once-fixtures. Returns Promise if any test is async."
-  [& test-vars]
-  (let [once-fixtures (get-once-fixtures)
+  "Runs tests and reports a summary. Accepts any of:
+   - no args: run every registered test across all namespaces.
+   - namespace name strings: run tests registered under each given ns.
+   - explicit test fns: run those fns directly.
+   Initializes the env if none is set. Returns (or resolves to, for async
+   tests) the :report-counters summary map."
+  [& args]
+  (let [test-vars (cond
+                    (empty? args)
+                    (registered-tests)
+                    (string? (first args))
+                    (vec (mapcat registered-tests args))
+                    :else
+                    args)
+        _ (when (nil? *current-env*) (set-env! (empty-env)))
+        once-fixtures (get-once-fixtures)
         run-all (fn []
                   (reduce
                    (fn [chain v]
@@ -146,7 +175,13 @@
                        (.then chain (fn [_] (test-var v)))
                        (test-var v)))
                    nil
-                   test-vars))]
-    (if (seq once-fixtures)
-      ((join-fixtures once-fixtures) run-all)
-      (run-all))))
+                   test-vars))
+        finish (fn [_]
+                 (report {:type :summary})
+                 (:report-counters (get-current-env)))
+        chain (if (seq once-fixtures)
+                ((join-fixtures once-fixtures) run-all)
+                (run-all))]
+    (if (async? chain)
+      (.then chain finish)
+      (finish nil))))

--- a/test-resources/cljs_test_smoke.cljs
+++ b/test-resources/cljs_test_smoke.cljs
@@ -84,6 +84,21 @@
       (is (= 2 (:pass inner-result))
           "returned summary reflects only the inner run's passes"))))
 
+(deftest report-only-counts-pass-fail-error-test
+  (testing "non-result :type values don't bump :report-counters"
+    (let [saved-env (t/get-current-env)]
+      (t/set-env! (t/empty-env))
+      (t/report {:type :summary})
+      (t/report {:type :begin-test-ns :ns "x"})
+      (t/report {:type :end-test-ns :ns "x"})
+      (let [counters (:report-counters (t/get-current-env))]
+        (t/set-env! saved-env)
+        (is (zero? (:test counters)) ":test stays 0")
+        (is (zero? (:pass counters)) ":pass stays 0")
+        (is (nil? (:summary counters)) "no bogus :summary key added")
+        (is (nil? (:begin-test-ns counters))
+            "no bogus :begin-test-ns key added")))))
+
 (defn ^:async -main []
   (t/set-env! (t/empty-env))
   (t/test-var math-test)
@@ -93,6 +108,7 @@
   (t/test-var per-ns-each-fixtures-test)
   (t/test-var per-ns-once-fixtures-test)
   (t/test-var run-tests-counter-isolation-test)
+  (t/test-var report-only-counts-pass-fail-error-test)
   (t/report {:type :summary}))
 
 (-main)

--- a/test-resources/cljs_test_smoke.cljs
+++ b/test-resources/cljs_test_smoke.cljs
@@ -26,12 +26,58 @@
         (resolve))
       5))))
 
+(deftest per-ns-each-fixtures-test
+  (testing "each-fixtures fire only for tests in the matching ns"
+    (let [saved-env (t/get-current-env)
+          log (atom [])
+          mk-fix (fn [tag]
+                   (fn [test-fn]
+                     (swap! log conj (str tag "-setup"))
+                     (test-fn)
+                     (swap! log conj (str tag "-teardown"))))
+          mk-test (fn [name-str ns-str]
+                    (with-meta (fn [] (is true))
+                      {:name name-str :ns ns-str}))]
+      (t/set-env! (t/empty-env))
+      (t/set-each-fixtures! "ns.a" [(mk-fix "a")])
+      (t/set-each-fixtures! "ns.b" [(mk-fix "b")])
+      (t/test-var (mk-test "t-a" "ns.a"))
+      (t/test-var (mk-test "t-b" "ns.b"))
+      (t/set-env! saved-env)
+      (is (= ["a-setup" "a-teardown" "b-setup" "b-teardown"] @log)
+          "each ns sees only its own fixture"))))
+
+(deftest per-ns-once-fixtures-test
+  (testing "once-fixtures wrap each ns's tests separately"
+    (let [saved-env (t/get-current-env)
+          log (atom [])
+          mk-fix (fn [tag]
+                   (fn [test-fn]
+                     (swap! log conj (str tag "-once-setup"))
+                     (test-fn)
+                     (swap! log conj (str tag "-once-teardown"))))
+          mk-test (fn [name-str ns-str]
+                    (with-meta (fn [] (swap! log conj name-str) (is true))
+                      {:name name-str :ns ns-str}))]
+      (t/set-env! (t/empty-env))
+      (t/set-once-fixtures! "ns.a" [(mk-fix "a")])
+      (t/set-once-fixtures! "ns.b" [(mk-fix "b")])
+      (t/run-tests (mk-test "a-1" "ns.a")
+                   (mk-test "a-2" "ns.a")
+                   (mk-test "b-1" "ns.b"))
+      (t/set-env! saved-env)
+      (is (= ["a-once-setup" "a-1" "a-2" "a-once-teardown"
+              "b-once-setup" "b-1" "b-once-teardown"] @log)
+          "each ns's once-fixture wraps only that ns's tests"))))
+
 (defn ^:async -main []
   (t/set-env! (t/empty-env))
   (t/test-var math-test)
   (t/test-var thrown-test)
   (t/test-var expected-failure-test)
   (js-await (t/test-var async-test))
+  (t/test-var per-ns-each-fixtures-test)
+  (t/test-var per-ns-once-fixtures-test)
   (t/report {:type :summary}))
 
 (-main)

--- a/test-resources/cljs_test_smoke.cljs
+++ b/test-resources/cljs_test_smoke.cljs
@@ -1,0 +1,37 @@
+(ns cljs-test-smoke
+  (:require [cljs.test :as t :refer [deftest is testing are]]))
+
+(deftest math-test
+  (testing "basic math"
+    (is (= 4 (+ 2 2)))
+    (are [x y sum] (= sum (+ x y))
+      1 1 2
+      2 3 5
+      10 20 30)))
+
+(deftest thrown-test
+  (is (thrown? js/Error (throw (js/Error. "boom"))))
+  (is (thrown-with-msg? js/Error #"boom"
+        (throw (js/Error. "boom!")))))
+
+(deftest expected-failure-test
+  (is (= :foo :bar) "intentional"))
+
+(deftest ^:async async-test
+  (js/Promise.
+   (fn [resolve]
+     (js/setTimeout
+      (fn []
+        (is (= 42 (* 6 7)))
+        (resolve))
+      5))))
+
+(defn ^:async -main []
+  (t/set-env! (t/empty-env))
+  (t/test-var math-test)
+  (t/test-var thrown-test)
+  (t/test-var expected-failure-test)
+  (js-await (t/test-var async-test))
+  (t/report {:type :summary}))
+
+(-main)

--- a/test-resources/cljs_test_smoke.cljs
+++ b/test-resources/cljs_test_smoke.cljs
@@ -70,6 +70,20 @@
               "b-once-setup" "b-1" "b-once-teardown"] @log)
           "each ns's once-fixture wraps only that ns's tests"))))
 
+(deftest run-tests-counter-isolation-test
+  (testing "an inner run-tests doesn't disturb the caller's counters"
+    (let [before (:report-counters (t/get-current-env))
+          inner-result (t/run-tests
+                        (with-meta (fn [] (is true)) {:name "inner-1" :ns "x"})
+                        (with-meta (fn [] (is true)) {:name "inner-2" :ns "x"}))
+          after (:report-counters (t/get-current-env))]
+      (is (= before after)
+          "outer counters are restored after run-tests returns")
+      (is (= 2 (:test inner-result))
+          "returned summary reflects only the inner run's tests")
+      (is (= 2 (:pass inner-result))
+          "returned summary reflects only the inner run's passes"))))
+
 (defn ^:async -main []
   (t/set-env! (t/empty-env))
   (t/test-var math-test)
@@ -78,6 +92,7 @@
   (js-await (t/test-var async-test))
   (t/test-var per-ns-each-fixtures-test)
   (t/test-var per-ns-once-fixtures-test)
+  (t/test-var run-tests-counter-isolation-test)
   (t/report {:type :summary}))
 
 (-main)

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2827,6 +2827,25 @@ new Foo();")
     (testing "no truth check"
       (is (str/includes? s "if (y1)")))))
 
+(deftest with-meta-on-fn-test
+  (testing "with-meta on a fn returns a callable carrying meta"
+    (is (true? (jsv! '(let [f (fn [] :ok)
+                            g (with-meta f {:name "foo"})]
+                        (fn? g))))
+        "fn? stays true")
+    (is (= "foo" (jsv! '(let [f (fn [] :ok)
+                              g (with-meta f {:name "foo"})]
+                          (:name (meta g)))))
+        ":name round-trips through (meta ...)")
+    (is (= 42 (jsv! '(let [f (fn [x] (* x 2))
+                           g (with-meta f {:tag :doubler})]
+                       (g 21))))
+        "the wrapped fn forwards args to the original"))
+  (testing "the original fn is not mutated"
+    (is (nil? (jsv! '(let [f (fn [] :ok)
+                           _ (with-meta f {:name "foo"})]
+                       (meta f)))))))
+
 (defn init []
   (t/run-tests 'squint.compiler-test
                'squint.jsx-test


### PR DESCRIPTION
Makes squint recognize (:require [cljs.test :refer [deftest is testing are]]) and friends out of the box, so user code can use the standard cljs.test API without vendoring macros or a runtime namespace into their project.

- src/squint/test.cljs: runtime (report, run-tests, test-var, fixtures, ^:async), pre-compiled to src/squint/test.mjs and shipped via package.json.
- src/squint/internal/test.cljc: deftest/is/testing/are/deftest-/use-fixtures as compiler-built-in macros, registered through built-in-macro-nss.
- compiler_common: resolve-ns and resolve-macro-ns learn to map cljs.test/clojure.test to the squint runtime; symbol emit falls back to the built-in ns->libname mapping so macro-generated qualified refs auto-import; :refer'd macro names are filtered out of runtime imports while still being tracked in :refers for lookup.
- bb tasks: compile-test-runtime regenerates test.mjs on build/test; test-cljs-test compiles test-resources/cljs_test_smoke.cljs and asserts on the summary output, wired into test-squint for CI.