### PR TITLE
Recognize test.check macros and namespaces for cherry

### DIFF
--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -315,16 +315,20 @@
        (clojure.test cljs.test) 'cherry.test
        alias))))
 
-(def ^:private builtin-test-macro-names
-  '#{deftest deftest- is testing are use-fixtures})
+(def ^:private builtin-macro-names-by-ns
+  '{cljs.test #{deftest deftest- is testing are use-fixtures}
+    clojure.test #{deftest deftest- is testing are use-fixtures}
+    cherry.test #{deftest deftest- is testing are use-fixtures}
+    squint.test #{deftest deftest- is testing are use-fixtures}
+    clojure.test.check.clojure-test #{defspec}
+    clojure.test.check.properties #{for-all}})
 
 (defn builtin-refer-is-macro?
   "Returns true when a `:refer`'d symbol is known to be a compiler built-in
   macro and must not be emitted as a runtime import."
   [original-libname refer-sym]
   (and (symbol? original-libname)
-       (contains? '#{cljs.test clojure.test cherry.test squint.test} original-libname)
-       (contains? builtin-test-macro-names refer-sym)))
+       (contains? (get builtin-macro-names-by-ns original-libname) refer-sym)))
 
 (defn resolve-ns [env alias]
   (let [import-maps (:import-maps env)]
@@ -348,6 +352,10 @@
         (cljs.set clojure.set) "cherry-cljs/lib/clojure.set.js"
         (cljs.pprint clojure.pprint) "cherry-cljs/lib/cljs.pprint.js"
         (cljs.test clojure.test) "cherry-cljs/lib/clojure.test.js"
+        (clojure.test.check
+         clojure.test.check.generators
+         clojure.test.check.properties
+         clojure.test.check.clojure-test) "cherry-cljs/lib/clojure.test.check.js"
         alias)
       alias)))
 


### PR DESCRIPTION
Corresponding squint change for [squint-cljs/cherry#184](https://github.com/squint-cljs/cherry/pull/184), targeting `cljs-test-builtin` branch. Can retarget if/when that branch lands.

- [ ] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
