### PR TITLE
allow compile forms directly

### DIFF
--- a/examples/babashka/alpinejs.clj
+++ b/examples/babashka/alpinejs.clj
@@ -10,7 +10,7 @@
 
 (def state (atom nil))
 (defn ->js [form]
-  (let [res (squint.compiler/compile-string* (str form) {:core-alias "$squint_core"})]
+  (let [res (squint.compiler/compile* (str form) {:core-alias "$squint_core"})]
     (reset! state res)
     (h/raw (:body res))))
 

--- a/examples/babashka/alpinejs_tictactoe.clj
+++ b/examples/babashka/alpinejs_tictactoe.clj
@@ -10,7 +10,7 @@
 
 (def state (atom nil))
 (defn ->js [form]
-  (let [res (squint.compiler/compile-string* (str form) {:core-alias "$squint_core"})]
+  (let [res (squint.compiler/compile* (str form) {:core-alias "$squint_core"})]
     (reset! state res)
     (h/raw (:body res))))
 

--- a/examples/babashka/index.clj
+++ b/examples/babashka/index.clj
@@ -10,7 +10,7 @@
 
 (def state (atom nil))
 (defn ->js [form]
-  (let [res (squint.compiler/compile-string* (str form))]
+  (let [res (squint.compiler/compile* (str form))]
     (reset! state res)
     (:body res)))
 

--- a/src/squint/compiler.cljc
+++ b/src/squint/compiler.cljc
@@ -421,12 +421,12 @@
                                :auto-resolve-ns true
                                :auto-resolve @*aliases*)))
 
-(defn transpile-string*
-  ([s] (transpile-string* s {}))
+(defn transpile*
+  ([s] (transpile* s {}))
   ([s env]
    (let [env (merge {:ns-state (atom {})
                      :context :statement} env)
-         forms (read-forms s)
+         forms (if (string? s) (read-forms s) s)
          max-form-idx (dec (count forms))
          return? (= :return (:context env))
          env (if return? (assoc env :context :statement) env)]
@@ -452,9 +452,9 @@
                     (rest forms)
                     (inc form-idx)))))))))
 
-(defn compile-string*
-  ([s] (compile-string* s nil))
-  ([s opts] (compile-string* s opts nil))
+(defn compile*
+  ([s] (compile* s nil))
+  ([s opts] (compile* s opts nil))
   ([s {:keys [elide-exports
               elide-imports
               core-alias
@@ -490,13 +490,13 @@
                    *cljs-ns* (:ns opts *cljs-ns*)
                    cc/*target* :squint
                    cc/*async* (:async opts)]
-           (let [transpiled (transpile-string* s (assoc opts
-                                                        :core-alias core-alias
-                                                        :imports imports
-                                                        :jsx false
-                                                        :pragmas pragmas
-                                                        :need-html-import need-html-import
-                                                        :need-multi-import need-multi-import))
+           (let [transpiled (transpile* s (assoc opts
+                                                 :core-alias core-alias
+                                                 :imports imports
+                                                 :jsx false
+                                                 :pragmas pragmas
+                                                 :need-html-import need-html-import
+                                                 :need-multi-import need-multi-import))
                  jsx *jsx*
                  _ (when (and jsx jsx-runtime)
                      (swap! imports str
@@ -561,7 +561,7 @@
 
 #?(:cljs
    (defn compileStringEx [s opts state]
-     (let [res (compile-string* s (clj-ize-opts opts) (clj-ize-opts state))]
+     (let [res (compile* s (clj-ize-opts opts) (clj-ize-opts state))]
        (clj->js res))))
 
 (defn compile-string
@@ -572,5 +572,5 @@
                          opts)
                  :default opts)
          {:keys [javascript]}
-         (compile-string* s opts)]
+         (compile* s opts)]
      javascript)))

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -1980,30 +1980,30 @@ globalThis.foo.fs = fs;")))))
     #_(println (jss! (str (fs/readFileSync "test-resources/defclass_test.cljs"))))
     (is (str/includes? (squint/compile-string "(defclass Foo-bar (constructor [this]))")
                        "export { Foo_bar }"))
-    (is (str/includes? (:javascript (squint/compile-string* "(defclass Foo (constructor [this]))" {:repl true
+    (is (str/includes? (:javascript (squint/compile* "(defclass Foo (constructor [this]))" {:repl           true
                                                                                                    :context :return}))
                        "return Foo"))
-    (is (not (str/includes? (:javascript (squint/compile-string* "(defclass WithoutConstructor Object (toString [_] \"bar\"))"))
+    (is (not (str/includes? (:javascript (squint/compile* "(defclass WithoutConstructor Object (toString [_] \"bar\"))"))
                             "constructor")))
     (let [source (str (fs/readFileSync "test-resources/defclass_test.cljs"))]
       (-> (p/let [v (jsv! source)
                   _ (is (= "<<<<1-3-3>>>>,1-3-3,true,false,42,4,6,1,2,foo,bar,3" (str v)))
                   state {}
                   {:keys [javascript] :as state}
-                  (squint/compile-string*  "
+                  (squint/compile* "
 (defclass Foo (constructor [this]) Object (toString [_] \"foo\"))
 (defclass WithoutConstructor Object (toString [_] \"bar\"))"
-                                           {:repl true
+                                   {:repl true
                                             :context :return
                                             :elide-exports true}
-                                           state)
+                                   state)
                   _ (js/eval (wrap-async javascript))
                   {:keys [_state javascript]}
-                  (squint/compile-string* "[(str (new Foo)) (str (new WithoutConstructor))]"
-                                          {:repl true
+                  (squint/compile* "[(str (new Foo)) (str (new WithoutConstructor))]"
+                                   {:repl true
                                            :context :return
                                            :elide-exports true}
-                                          state)
+                                   state)
                   v (js/eval (wrap-async javascript))
                   _ (is (eq ["foo" "bar"] v))])
           (p/finally done)))))
@@ -2053,7 +2053,7 @@ globalThis.foo.fs = fs;")))))
 
 (deftest alias-conflict-test
   (let [expr (fs/readFileSync "test-resources/alias_conflict_test.cljs" "UTF-8")
-        js (:javascript (squint/compile-string* expr {:core-alias "squint_core"}))]
+        js (:javascript (squint/compile* expr {:core-alias "squint_core"}))]
     (when (not (fs/existsSync "test-output"))
       (fs/mkdirSync "test-output"))
     (fs/writeFileSync "test-output/foo.mjs" js)
@@ -2490,7 +2490,7 @@ new Foo();")
     (doseq [code [code (str/replace "(do %s)" "%s" code)]
             repl? [true false]
             return? [true false]]
-      (let [{:keys [pragmas javascript]} (squint/compile-string* code {:repl repl?
+      (let [{:keys [pragmas javascript]} (squint/compile* code {:repl           repl?
                                                                        :context (if return?
                                                                                   :return
                                                                                   :statement)})]
@@ -2537,7 +2537,7 @@ new Foo();")
   (is (true? (jsv! "(defn foo [x] (and (int? x) (< 10 x 18))) (foo 12)"))))
 
 (deftest no-private-export-test
-  (let [exports (:exports (squint/compile-string* "(defn- foo []) (defn bar [])"))]
+  (let [exports (:exports (squint/compile* "(defn- foo []) (defn bar [])"))]
     (is (not (str/includes? exports "foo")))
     (is (str/includes? exports "bar"))))
 

--- a/test/squint/html_test.cljs
+++ b/test/squint/html_test.cljs
@@ -17,7 +17,7 @@
     (is (str/includes?
          (jss! "#html ^foo/bar [:div \"Hello\"]")
          "foo.bar`<div>Hello</div>"))
-    (let [{:keys [imports body]} (squint.compiler/compile-string* "(defn foo [x] #html [:div \"Hello\" x])")]
+    (let [{:keys [imports body]} (squint.compiler/compile* "(defn foo [x] #html [:div \"Hello\" x])")]
       (is (str/includes? imports "import * as squint_html from 'squint-cljs/src/squint/html.js'"))
       (is (str/includes? body "squint_html.tag`<div>Hello${x}</div>")))
     (let [js (squint.compiler/compile-string "

--- a/test/squint/multi_test.cljs
+++ b/test/squint/multi_test.cljs
@@ -11,11 +11,11 @@
     (js/eval js)))
 
 (deftest no-import-when-unused
-  (let [{:keys [imports]} (squint/compile-string* "(+ 1 2) (defn f [x] (inc x))")]
+  (let [{:keys [imports]} (squint/compile* "(+ 1 2) (defn f [x] (inc x))")]
     (is (not (str/includes? imports "squint/multi.js")))))
 
 (deftest import-when-defmulti-used
-  (let [{:keys [imports body]} (squint/compile-string* "(defmulti area :shape)")]
+  (let [{:keys [imports body]} (squint/compile* "(defmulti area :shape)")]
     (is (str/includes? imports "import * as squint_multi from 'squint-cljs/src/squint/multi.js'"))
     (is (str/includes? body "squint_multi.defmulti(\"area\""))))
 

--- a/test/squint/test_utils.cljs
+++ b/test/squint/test_utils.cljs
@@ -52,9 +52,9 @@
   ([expr opts]
    (if (string? expr)
      (let [{:keys [pragmas body]}
-           (squint/compile-string* expr (merge {:elide-imports true
-                                                :core-alias "squint_core"}
-                                               opts))]
+           (squint/compile* expr (merge {:elide-imports     true
+                                         :core-alias "squint_core"}
+                                        opts))]
        (str pragmas body))
      (squint/transpile-form expr (merge {:elide-imports true
                                          :core-alias "squint_core"}


### PR DESCRIPTION
I am proposing a way to render simple server-side snippets without performing the `forms -> string-> forms` roundtrip.
I found this approach workable for my use case, but I’m not certain whether it aligns with the project’s internals. Please let me know if it’s acceptable or can be improved, or feel free to reject it.

- [x] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code).

- [ ] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [ ] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
