### PR TITLE
Fix #810: shorthand class erased when attrs map has no :class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - [#809](https://github.com/squint-cljs/squint/issues/809): add `squint.compiler/compile*` and `squint.compiler/transpile*` which accept either a string or a sequence of pre-parsed forms, skipping the `forms -> string -> forms` roundtrip for SSR use cases. The previous names `compile-string*` / `transpile-string*` are retained as deprecated aliases.
+- Fix [#810](https://github.com/squint-cljs/squint/issues/810): shorthand classes in `#html` / `#jsx` were erased when an attrs map was present without a `:class` key (e.g. `[:div.myclass {}]`).
 
 ## 0.11.188
 

--- a/src/squint/compiler_common.cljc
+++ b/src/squint/compiler_common.cljc
@@ -1435,11 +1435,12 @@ break;}" body)
        (.substring tag (unchecked-inc-int class-index)))]))
 
 (defn- merge-attrs [attrs short-attrs]
-  (let [attrs (if-let [c (:class attrs)]
-                (if-let [sc (:class short-attrs)]
-                  (assoc attrs :class (str sc " " c))
-                  attrs)
-                attrs)
+  (let [attrs (let [c (:class attrs)
+                    sc (:class short-attrs)]
+                (cond
+                  (and c sc) (assoc attrs :class (str sc " " c))
+                  sc (assoc attrs :class sc)
+                  :else attrs))
         attrs (if-let [id (:id short-attrs (:id attrs))]
                 (assoc attrs :id id)
                 attrs)]

--- a/test/squint/html_test.cljs
+++ b/test/squint/html_test.cljs
@@ -130,13 +130,17 @@
   (t/async done
     (let [js (squint.compiler/compile-string
               "[(str #html [:div.container])
-                (str #html [:a#foo.bar.baz {:class \"quux\"}])]"
+                (str #html [:a#foo.bar.baz {:class \"quux\"}])
+                (str #html [:div.myclass {}])
+                (str #html [:div.myclass {:data-foo \"x\"}])]"
               {:repl true :elide-exports true :context :return})
           js (str/replace "(async function() { %s } )()" "%s" js)]
       (-> (js/eval js)
           (.then
            #(doseq [[k v] (map vector ["<div class=\"container\"></div>"
-                                       "<a class=\"bar baz quux\" id=\"foo\"></a>"] %)]
+                                       "<a class=\"bar baz quux\" id=\"foo\"></a>"
+                                       "<div class=\"myclass\"></div>"
+                                       "<div data-foo=\"x\" class=\"myclass\"></div>"] %)]
               (is (html= k v))))
           (.catch #(is false "nooooo"))
           (.finally done)))))

--- a/test/squint/jsx_test.cljs
+++ b/test/squint/jsx_test.cljs
@@ -81,6 +81,10 @@
     (is (= "<div class=\"container\"></div>" (test-jsx "#jsx [:div.container]"))))
   (testing "id and classes shorthand"
     (is (= "<div class=\"foo bar\" id=\"my-id\"></div>" (test-jsx "#jsx [:div#my-id.foo.bar]"))))
+  (testing "class shorthand with empty props (#810)"
+    (is (= "<div class=\"myclass\"></div>" (test-jsx "#jsx [:div.myclass {}]"))))
+  (testing "class shorthand with non-class props (#810)"
+    (is (= "<div data-foo=\"x\" class=\"myclass\"></div>" (test-jsx "#jsx [:div.myclass {:data-foo \"x\"}]"))))
   (testing "return position"
     (is (= 1 (count (re-seq #"return" (jss! "(defn foo [] #jsx [:button \"dude\"])"
                                             {:jsx-runtime true})))))))


### PR DESCRIPTION
merge-attrs only kept the tag-shorthand class when the user attrs already had a :class key, dropping it for `[:div.foo {}]` and similar.

