### PR TITLE
Add minimal reify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - Fix [#815](https://github.com/squint-cljs/squint/issues/815): `str` wrapping known-numeric infix expressions in `??''`, which esbuild flagged as `suspicious-nullish-coalescing`.
+- [#817](https://github.com/squint-cljs/squint/issues/817): add minimal `reify`
 
 ## 0.11.189
 

--- a/src/squint/compiler.cljc
+++ b/src/squint/compiler.cljc
@@ -87,6 +87,7 @@
                              'defprotocol protocols/core-defprotocol
                              'extend-type protocols/core-extend-type
                              'extend-protocol protocols/core-extend-protocol
+                             'reify protocols/core-reify
                              'deftype deftype/core-deftype
                              'defn core-defn
                              'defn- core-defn-

--- a/src/squint/internal/protocols.cljc
+++ b/src/squint/internal/protocols.cljc
@@ -156,3 +156,11 @@
         (bar [x y] ...)))"
   [_ _ p & specs]
   (emit-extend-protocol p specs))
+
+(core/defn core-reify
+  [_ _ & impls]
+  (core/let [t (gensym "t_reify_")]
+    `(do
+       (deftype ~t []
+         ~@impls)
+       (new ~t))))

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -590,7 +590,20 @@
           (jsv! '(do (defprotocol IFoo (-foo [_]))
                      (let [xs [10 20 30]]
                        (mapv (fn [x] (-foo (reify IFoo (-foo [_] x))))
-                             xs)))))))
+                             xs))))))
+  (is (true? (jsv! '(do (defprotocol P
+                          (a? [h])
+                          (b? [h])
+                          (c [h]))
+                        (defn mk-p [v]
+                          (reify P
+                            (a? [_] true)
+                            (b? [_] false)
+                            (c [_] v)))
+                        (let [h (mk-p :foo)]
+                          (and (a? h)
+                               (not (b? h))
+                               (= :foo (c h)))))))))
 
 (deftest set-test
   (is (eq (js/Set. #js [1 2 3]) (jsv! #{1 2 3})))

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -558,11 +558,11 @@
                      (bar (->Foo) 1 2))))))
 
 (deftest satisfies?-test
-  #_#_(is (jsv! '(do (defprotocol IFoo)
-                     (satisfies? (reify IFoo)))))
+  (is (jsv! '(do (defprotocol IFoo)
+                 (satisfies? IFoo (reify IFoo)))))
   (is (jsv! '(do (defprotocol IFoo (-foo [_]))
-                 (satisfies? (reify IFoo
-                               (-foo [_] "bar"))))))
+                 (satisfies? IFoo (reify IFoo
+                                    (-foo [_] "bar"))))))
   (is (jsv! '(do (defprotocol IFoo)
                  (deftype Foo [] IFoo)
                  (satisfies? IFoo (->Foo)))))
@@ -575,6 +575,22 @@
   (is (jsv! '(do (defprotocol IFoo)
                  (extend-type string IFoo)
                  (satisfies? IFoo "bar")))))
+
+(deftest reify-test
+  (is (jsv! '(do (defprotocol IFoo (-foo [_]))
+                 (defprotocol IBar (-bar [_]))
+                 (let [r (reify IFoo (-foo [_] :foo)
+                                IBar (-bar [_] :bar))]
+                   (and (satisfies? IFoo r) (satisfies? IBar r))))))
+  (is (= "b" (jsv! '(do (defprotocol IFoo (-foo [_]) (-bar [_]))
+                        (-foo (reify IFoo
+                                (-foo [this] (-bar this))
+                                (-bar [_] "b")))))))
+  (is (eq #js [10 20 30]
+          (jsv! '(do (defprotocol IFoo (-foo [_]))
+                     (let [xs [10 20 30]]
+                       (mapv (fn [x] (-foo (reify IFoo (-foo [_] x))))
+                             xs)))))))
 
 (deftest set-test
   (is (eq (js/Set. #js [1 2 3]) (jsv! #{1 2 3})))


### PR DESCRIPTION
Please answer the following questions and leave the below in as part of your PR.

- [X] This PR corresponds to an [issue with a clear problem statement]
- #817 

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions
Uncomments the stubs plus adds a new `reify-test`

- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
Notes #817.

Let me know if you have any questions! I left the unused args as `_ _` -- I saw some discrepancy between https://github.com/squint-cljs/squint/blob/db49293fcbf4207d0f3295bb2da8683d73d1bd92/src/squint/compiler.cljc#L296 suggesting `form env` but https://github.com/squint-cljs/squint/blob/db49293fcbf4207d0f3295bb2da8683d73d1bd92/src/squint/internal/protocols.cljc#L28 and https://github.com/squint-cljs/squint/blob/db49293fcbf4207d0f3295bb2da8683d73d1bd92/src/squint/internal/protocols.cljc#L102 doing `env` preceding `form`. https://github.com/squint-cljs/squint/blob/db49293fcbf4207d0f3295bb2da8683d73d1bd92/src/squint/internal/protocols.cljc#L157 also used `_ _`, so I went with that.