### PR TITLE
Fix #820: coerce :macros option keys back to symbols for JS callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Unreleased
 
 - Fix [#815](https://github.com/squint-cljs/squint/issues/815): `str` wrapping known-numeric infix expressions in `??''`, which esbuild flagged as `suspicious-nullish-coalescing`.
+- Fix [#820](https://github.com/squint-cljs/squint/issues/820): `:macros` option silently ignored when passed to `compileString` / `compileStringEx` from JavaScript callers (string keys were keyword-ized by `clj-ize-opts` and no longer matched the symbol-keyed macro lookups in `compile*`).
 
 ## 0.11.189
 

--- a/src/squint/compiler.cljc
+++ b/src/squint/compiler.cljc
@@ -551,13 +551,26 @@
                     :ns-state (:ns-state opts)))))))))
 
 #?(:cljs
+   (defn- macros-opt->symbol-keys
+     [macros-map]
+     (into {}
+           (map (fn [[ns-k inner]]
+                  [(symbol (name ns-k))
+                   (into {}
+                         (map (fn [[macro-k macro-fn]]
+                                [(symbol (name macro-k)) macro-fn])
+                              inner))]))
+           macros-map)))
+
+#?(:cljs
    (defn clj-ize-opts [opts]
      (let [opts (js->clj opts :keywordize-keys true)]
        (cond-> opts
          (:context opts) (update :context keyword)
          (:ns opts) (update :ns symbol)
          (:elide_imports opts) (assoc :elide-imports (:elide_imports opts))
-         (:elide_exports opts) (assoc :elide-exports (:elide_exports opts))))))
+         (:elide_exports opts) (assoc :elide-exports (:elide_exports opts))
+         (:macros opts) (update :macros macros-opt->symbol-keys)))))
 
 #?(:cljs
    (defn compileStringEx [s opts state]

--- a/test/squint/compiler_test.cljs
+++ b/test/squint/compiler_test.cljs
@@ -2742,6 +2742,24 @@ new Foo();")
                           :elide-exports true
                           :top-level false}))))))
 
+(deftest compile-string-macros-js-test
+  (let [compiler-macros #js {:custom
+                             #js {:expr-and (fn [_ _ & args]
+                                              (let [js (str/join " && " (repeat (count args) "(~{})"))]
+                                                (vary-meta
+                                                 (concat (list 'js* js) args)
+                                                 assoc :tag 'boolean)))}}
+        result (squint/compileStringEx
+                "(let [value 1]
+       (custom/expr-and (= value 1) (= 2 2)))"
+                #js {:context "expr"
+                     :macros compiler-macros
+                     :elide-imports true
+                     :elide-exports true
+                     :top-level false}
+                nil)]
+    (is (true? (js/eval (.-javascript result))))))
+
 (deftest issue-704-test
   (is (eq 10 (jsv! "(let [a (atom 1)] (while (< @a 10) (swap! a inc)) @a)"))))
 


### PR DESCRIPTION
Working on migrating a codebase to squint rather than cherry, and I'm hitting some regressions with runtime compilation using compileString.

- [X] This PR corresponds to an [issue with a clear problem statement](https://github.com/babashka/babashka/blob/master/doc/dev.md#start-with-an-issue-before-writing-code). #820

- [X] This PR contains a [test](https://github.com/babashka/babashka/blob/master/doc/dev.md#tests) to prevent against future regressions

- [X] I have updated the [CHANGELOG.md](https://github.com/squint-cljs/squint/blob/master/CHANGELOG.md) file with a description of the addressed issue.
